### PR TITLE
binary-serialise-cbor: Rip out compatibility with GHC 7.8

### DIFF
--- a/binary-serialise-cbor/binary-serialise-cbor.cabal
+++ b/binary-serialise-cbor/binary-serialise-cbor.cabal
@@ -12,7 +12,7 @@ copyright:           2015-2017 Duncan Coutts,
 category:            Codec
 build-type:          Simple
 cabal-version:       >= 1.21
-tested-with:         GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.1
+tested-with:         GHC == 7.10.3, GHC == 8.0.1
 
 description:
   This package is a shim around @cborg@, exposing an interface compatible with
@@ -25,36 +25,23 @@ source-repository head
 library
   default-language:  Haskell2010
   hs-source-dirs:      src
-  if impl(ghc >= 7.9)
-    reexported-modules:
-      Codec.Serialise            as Data.Binary.Serialise.CBOR,
-      Codec.Serialise.Class      as Data.Binary.Serialise.CBOR.Class,
-      Codec.Serialise.Decoding   as Data.Binary.Serialise.CBOR.Decoding,
-      Codec.Serialise.Encoding   as Data.Binary.Serialise.CBOR.Encoding,
-      Codec.CBOR.FlatTerm        as Data.Binary.Serialise.CBOR.FlatTerm,
-      Codec.Serialise.IO         as Data.Binary.Serialise.CBOR.IO,
-      Codec.CBOR.Magic           as Data.Binary.Serialise.CBOR.Magic,
-      Codec.CBOR.Pretty          as Data.Binary.Serialise.CBOR.Pretty,
-      Codec.Serialise.Properties as Data.Binary.Serialise.CBOR.Properties,
-      Codec.CBOR.Write           as Data.Binary.Serialise.CBOR.Write,
-      Codec.CBOR.Term            as Data.Binary.Serialise.CBOR.Term,
-      Codec.Serialise.Tutorial   as Data.Binary.Serialise.CBOR.Tutorial
-    exposed-modules: Data.Binary.Serialise.CBOR.Read
-  else
-    -- GHC 7.8 doesn't support module re-exports
-    exposed-modules:
-      Data.Binary.Serialise.CBOR,
-      Data.Binary.Serialise.CBOR.Class,
-      Data.Binary.Serialise.CBOR.Decoding,
-      Data.Binary.Serialise.CBOR.Encoding,
-      Data.Binary.Serialise.CBOR.FlatTerm,
-      Data.Binary.Serialise.CBOR.IO,
-      Data.Binary.Serialise.CBOR.Magic,
-      Data.Binary.Serialise.CBOR.Pretty,
-      Data.Binary.Serialise.CBOR.Properties,
-      Data.Binary.Serialise.CBOR.Read,
-      Data.Binary.Serialise.CBOR.Write,
-      Data.Binary.Serialise.CBOR.Term
+  reexported-modules:
+    Codec.Serialise            as Data.Binary.Serialise.CBOR,
+    Codec.Serialise.Class      as Data.Binary.Serialise.CBOR.Class,
+    Codec.Serialise.Decoding   as Data.Binary.Serialise.CBOR.Decoding,
+    Codec.Serialise.Encoding   as Data.Binary.Serialise.CBOR.Encoding,
+    Codec.CBOR.FlatTerm        as Data.Binary.Serialise.CBOR.FlatTerm,
+    Codec.Serialise.IO         as Data.Binary.Serialise.CBOR.IO,
+    Codec.CBOR.Magic           as Data.Binary.Serialise.CBOR.Magic,
+    Codec.CBOR.Pretty          as Data.Binary.Serialise.CBOR.Pretty,
+    Codec.Serialise.Properties as Data.Binary.Serialise.CBOR.Properties,
+    Codec.CBOR.Write           as Data.Binary.Serialise.CBOR.Write,
+    Codec.CBOR.Term            as Data.Binary.Serialise.CBOR.Term,
+    Codec.Serialise.Tutorial   as Data.Binary.Serialise.CBOR.Tutorial
+  exposed-modules: Data.Binary.Serialise.CBOR.Read
+
+  if impl(ghc <= 7.8)
+     buildable: False
 
   build-depends:
     base < 5,

--- a/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR.hs
+++ b/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR.hs
@@ -1,5 +1,0 @@
-module Data.Binary.Serialise.CBOR
- ( module X
- ) where
-
-import Codec.Serialise as X

--- a/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/Class.hs
+++ b/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/Class.hs
@@ -1,5 +1,0 @@
-module Data.Binary.Serialise.CBOR.Class
- ( module X
- ) where
-
-import Codec.Serialise.Class as X

--- a/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/Decoding.hs
+++ b/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/Decoding.hs
@@ -1,5 +1,0 @@
-module Data.Binary.Serialise.CBOR.Decoding
- ( module X
- ) where
-
-import Codec.Serialise.Decoding as X

--- a/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/Encoding.hs
+++ b/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/Encoding.hs
@@ -1,5 +1,0 @@
-module Data.Binary.Serialise.CBOR.Encoding
- ( module X
- ) where
-
-import Codec.Serialise.Encoding as X

--- a/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/FlatTerm.hs
+++ b/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/FlatTerm.hs
@@ -1,5 +1,0 @@
-module Data.Binary.Serialise.CBOR.FlatTerm
- ( module X
- ) where
-
-import Codec.CBOR.FlatTerm as X

--- a/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/IO.hs
+++ b/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/IO.hs
@@ -1,5 +1,0 @@
-module Data.Binary.Serialise.CBOR.IO
- ( module X
- ) where
-
-import Codec.Serialise.IO as X

--- a/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/Magic.hs
+++ b/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/Magic.hs
@@ -1,5 +1,0 @@
-module Data.Binary.Serialise.CBOR.Magic
- ( module X
- ) where
-
-import Codec.CBOR.Magic as X

--- a/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/Pretty.hs
+++ b/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/Pretty.hs
@@ -1,5 +1,0 @@
-module Data.Binary.Serialise.CBOR.Pretty
- ( module X
- ) where
-
-import Codec.CBOR.Pretty as X

--- a/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/Properties.hs
+++ b/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/Properties.hs
@@ -1,5 +1,0 @@
-module Data.Binary.Serialise.CBOR.Properties
- ( module X
- ) where
-
-import Codec.Serialise.Properties as X

--- a/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/Term.hs
+++ b/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/Term.hs
@@ -1,5 +1,0 @@
-module Data.Binary.Serialise.CBOR.Term
- ( module X
- ) where
-
-import Codec.CBOR.Term as X

--- a/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/Write.hs
+++ b/binary-serialise-cbor/src/Data/Binary/Serialise/CBOR/Write.hs
@@ -1,5 +1,0 @@
-module Data.Binary.Serialise.CBOR.Write
- ( module X
- ) where
-
-import Codec.CBOR.Write as X


### PR DESCRIPTION
Cabal check won't allow my conditional export trick and I don't think the
compatibility is worth the cost for a wrapper library.