### PR TITLE
Ensure that surrogate Chars round-trip

### DIFF
--- a/cborg/src/Codec/CBOR/ByteArray.hs
+++ b/cborg/src/Codec/CBOR/ByteArray.hs
@@ -26,8 +26,9 @@ module Codec.CBOR.ByteArray
   , toSliced
   ) where
 
+import Data.Char (ord)
 import Data.Word
-import GHC.Exts (IsList(..))
+import GHC.Exts (IsList(..), IsString(..))
 
 import qualified Data.Primitive.ByteArray as Prim
 import qualified Data.ByteString as BS
@@ -63,6 +64,13 @@ instance Eq ByteArray where
 
 instance Ord ByteArray where
   ba1 `compare` ba2 = toSliced ba1 `compare` toSliced ba2
+
+instance IsString ByteArray where
+  fromString = fromList . map checkedOrd
+    where
+      checkedOrd c
+        | c > '\xff' = error "IsString(Codec.CBOR.ByteArray): Non-ASCII character"
+        | otherwise  = fromIntegral $ ord c
 
 instance IsList ByteArray where
   type Item ByteArray = Word8

--- a/serialise/serialise.cabal
+++ b/serialise/serialise.cabal
@@ -60,6 +60,7 @@ library
     Codec.Serialise.IO
     Codec.Serialise.Properties
     Codec.Serialise.Tutorial
+    Codec.Serialise.Internal.GeneralisedUTF8
 
   build-depends:
     array                   >= 0.4     && < 0.6,
@@ -115,6 +116,7 @@ test-suite tests
     Tests.Reference
     Tests.Reference.Implementation
     Tests.Deriving
+    Tests.GeneralisedUTF8
 
   build-depends:
     array                   >= 0.4     && < 0.6,

--- a/serialise/serialise.cabal
+++ b/serialise/serialise.cabal
@@ -110,6 +110,7 @@ test-suite tests
     Tests.Regress.Issue67
     Tests.Regress.Issue80
     Tests.Regress.Issue106
+    Tests.Regress.Issue135
     Tests.Regress.FlatTerm
     Tests.Reference
     Tests.Reference.Implementation

--- a/serialise/src/Codec/Serialise/Internal/GeneralisedUTF8.hs
+++ b/serialise/src/Codec/Serialise/Internal/GeneralisedUTF8.hs
@@ -1,0 +1,158 @@
+{-# LANGUAGE BangPatterns #-}
+
+module Codec.Serialise.Internal.GeneralisedUTF8
+    ( encodeGenUTF8
+    , UTF8Encoding(..)
+    , decodeGenUTF8
+      -- * Utilities
+    , isSurrogate
+    , isValid
+    ) where
+
+import Control.Monad.ST
+import Data.Bits
+import Data.Char
+import Data.Word
+import qualified Codec.CBOR.ByteArray.Sliced as BAS
+import Data.Primitive.ByteArray
+
+data UTF8Encoding = ConformantUTF8 | GeneralisedUTF8
+                  deriving (Show, Eq)
+
+-- | Is a 'Char' a UTF-16 surrogate?
+isSurrogate :: Char -> Bool
+isSurrogate c = (ord c .&. 0xd800) == 0xd800
+
+-- | Encode a string as (generalized) UTF-8. In addition to the encoding, we
+-- return a flag indicating whether the encoded string contained any surrogate
+-- characters, in which case the output is generalized UTF-8.
+encodeGenUTF8 :: String -> (BAS.SlicedByteArray, UTF8Encoding)
+encodeGenUTF8 st = runST $ do
+    ba <- newByteArray (length st)
+    go ba ConformantUTF8 0 st
+  where
+    go :: MutableByteArray s -> UTF8Encoding
+       -> Int -> [Char]
+       -> ST s (BAS.SlicedByteArray, UTF8Encoding)
+    go ba !enc !off  [] = do
+        ba' <- unsafeFreezeByteArray ba
+        return (BAS.SBA ba' 0 off, enc)
+    go ba enc off  (c:cs)
+      | off + 4 >= cap = do
+        ba' <- newByteArray (cap + cap `div` 2 + 1)
+        copyMutableByteArray ba' 0 ba 0 off
+        go ba' enc off (c:cs)
+
+      | c >= '\x10000' = do
+        writeByteArray ba (off+0) (0xf0 .|. (0x07 .&. shiftedByte 18))
+        writeByteArray ba (off+1) (0x80 .|. (0x3f .&. shiftedByte 12))
+        writeByteArray ba (off+2) (0x80 .|. (0x3f .&. shiftedByte  6))
+        writeByteArray ba (off+3) (0x80 .|. (0x3f .&. shiftedByte  0))
+        go ba enc (off+4) cs
+
+      | c >= '\x0800'  = do
+        writeByteArray ba (off+0) (0xe0 .|. (0x0f .&. shiftedByte 12))
+        writeByteArray ba (off+1) (0x80 .|. (0x3f .&. shiftedByte  6))
+        writeByteArray ba (off+2) (0x80 .|. (0x3f .&. shiftedByte  0))
+
+        -- Is this a surrogate character?
+        let enc'
+              | isSurrogate c = GeneralisedUTF8
+              | otherwise     = enc
+        go ba enc' (off+3) cs
+
+      | c >= '\x0080'  = do
+        writeByteArray ba (off+0) (0xc0 .|. (0x1f .&. shiftedByte  6))
+        writeByteArray ba (off+1) (0x80 .|. (0x3f .&. shiftedByte  0))
+        go ba enc (off+2) cs
+
+      | c <= '\x007f'  = do
+        writeByteArray ba off (fromIntegral n :: Word8)
+        go ba enc (off+1) cs
+
+      | otherwise      = error "encodeGenUTF8: Impossible"
+      where
+        cap = sizeofMutableByteArray ba
+        n = ord c
+        shiftedByte :: Int -> Word8
+        shiftedByte shft = fromIntegral $ n `shiftR` shft
+
+decodeGenUTF8 :: ByteArray -> String
+decodeGenUTF8 ba = go 0
+  where
+    !len = sizeofByteArray ba
+
+    index :: Int -> Int
+    index i = fromIntegral (ba `indexByteArray` i :: Word8)
+
+    go !off
+      | off == len = []
+
+      | n0 .&. 0xf8 == 0xf0 =
+        let n1 = index (off + 1)
+            n2 = index (off + 2)
+            n3 = index (off + 3)
+            c  = chr $  (n0 .&. 0x07) `shiftL` 18
+                    .|. (n1 .&. 0x3f) `shiftL` 12
+                    .|. (n2 .&. 0x3f) `shiftL`  6
+                    .|. (n3 .&. 0x3f)
+        in c : go (off + 4)
+
+      | n0 .&. 0xf0 == 0xe0 =
+        let n1 = index (off + 1)
+            n2 = index (off + 2)
+            c  = chr $  (n0 .&. 0x0f) `shiftL` 12
+                    .|. (n1 .&. 0x3f) `shiftL`  6
+                    .|. (n2 .&. 0x3f)
+        in c : go (off + 3)
+
+      | n0 .&. 0xe0 == 0xc0 =
+        let n1 = index (off + 1)
+            c  = chr $  (n0 .&. 0x1f) `shiftL`  6
+                    .|. (n1 .&. 0x3f)
+        in c : go (off + 2)
+
+      | otherwise =
+        let c =  chr $  (n0 .&. 0x7f)
+        in c : go (off + 1)
+      where !n0 = index off
+
+-- | Is the given byte sequence valid under the given encoding?
+isValid :: UTF8Encoding -> [Word8] -> Bool
+isValid encoding = go
+  where
+    go [] = True
+    go (b0:bs)
+      | inRange 0x00 0x7f b0 = go bs
+    go (b0:b1:bs)
+      | inRange 0xc2 0xdf b0
+      , inRange 0x80 0xbf b1 = go bs
+    go (0xe0:b1:b2:bs)
+      | inRange 0xa0 0xbf b1
+      , inRange 0x80 0xbf b2 = go bs
+    go (0xed:b1:_)
+      -- surrogate range
+      | encoding == ConformantUTF8
+      , inRange 0xa0 0xbf b1
+      = False
+    go (b0:b1:b2:bs)
+      | inRange 0xe1 0xef b0
+      , inRange 0x80 0xbf b1
+      , inRange 0x80 0xbf b2 = go bs
+    go (0xf0:b1:b2:b3:bs)
+      | inRange 0x90 0xbf b1
+      , inRange 0x80 0xbf b2
+      , inRange 0x80 0xbf b3 = go bs
+    go (b0:b1:b2:b3:bs)
+      | inRange 0xf1 0xf3 b0
+      , inRange 0x80 0xbf b1
+      , inRange 0x80 0xbf b2
+      , inRange 0x80 0xbf b3 = go bs
+    go (0xf4:b1:b2:b3:bs)
+      | inRange 0x80 0x8f b1
+      , inRange 0x80 0xbf b2
+      , inRange 0x80 0xbf b3 = go bs
+    go _ = False
+
+inRange :: Ord a => a -> a -> a -> Bool
+inRange lower upper x = lower <= x && x <= upper

--- a/serialise/tests/Main.hs
+++ b/serialise/tests/Main.hs
@@ -10,6 +10,7 @@ import qualified Tests.Reference as Reference
 import qualified Tests.Serialise as Serialise
 import qualified Tests.Negative  as Negative
 import qualified Tests.Deriving  as Deriving
+import qualified Tests.GeneralisedUTF8  as GeneralisedUTF8
 
 main :: IO ()
 main = Reference.loadTestCases >>= \tcs -> defaultMain $
@@ -22,4 +23,5 @@ main = Reference.loadTestCases >>= \tcs -> defaultMain $
     , IO.testTree
     , Regress.testTree
     , Deriving.testTree
+    , GeneralisedUTF8.testTree
     ]

--- a/serialise/tests/Tests/GeneralisedUTF8.hs
+++ b/serialise/tests/Tests/GeneralisedUTF8.hs
@@ -1,0 +1,37 @@
+module Tests.GeneralisedUTF8 where
+
+import GHC.Exts
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import qualified Data.ByteString as BS
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+import qualified Codec.CBOR.ByteArray as BA
+import Codec.Serialise.Internal.GeneralisedUTF8
+
+testEncoder :: String -> Property
+testEncoder s =
+    case encodeGenUTF8 s of
+      (ba, enc) ->
+          toList ba === BS.unpack (T.encodeUtf8 $ T.pack s)
+          .&&.
+          enc === correctEnc
+  where
+    correctEnc
+      | any isSurrogate s = GeneralisedUTF8
+      | otherwise         = ConformantUTF8
+
+testDecoder :: String -> Property
+testDecoder s =
+    decodeGenUTF8 ba === s
+  where
+    BA.BA ba = BA.fromByteString $ T.encodeUtf8 $ T.pack s
+
+testTree :: TestTree
+testTree =
+    testGroup "Generalised UTF-8 codec"
+        [ testProperty "encoder" testEncoder
+        , testProperty "decoder" testDecoder
+        ]

--- a/serialise/tests/Tests/Regress.hs
+++ b/serialise/tests/Tests/Regress.hs
@@ -7,7 +7,8 @@ import           Test.Tasty
 import qualified Tests.Regress.Issue13  as Issue13
 import qualified Tests.Regress.Issue67  as Issue67
 import qualified Tests.Regress.Issue80  as Issue80
-import qualified Tests.Regress.Issue106  as Issue106
+import qualified Tests.Regress.Issue106 as Issue106
+import qualified Tests.Regress.Issue135 as Issue135
 import qualified Tests.Regress.FlatTerm as FlatTerm
 
 --------------------------------------------------------------------------------
@@ -20,4 +21,5 @@ testTree = testGroup "Regression tests"
   , Issue67.testTree
   , Issue80.testTree
   , Issue106.testTree
+  , Issue135.testTree
   ]

--- a/serialise/tests/Tests/Regress/Issue135.hs
+++ b/serialise/tests/Tests/Regress/Issue135.hs
@@ -1,0 +1,34 @@
+-- Issue #135: Ensure that surrogate characters round-trip
+--
+module Tests.Regress.Issue135
+  ( testTree -- :: TestTree
+  ) where
+
+import           Codec.Serialise
+
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+import           Test.Tasty.HUnit
+
+newtype StringWithSurrogates = StringWithSurrogates String
+                             deriving (Show)
+
+instance Arbitrary StringWithSurrogates where
+  arbitrary =
+      fmap StringWithSurrogates $ listOf1
+      $ oneof [choose ('\xd800', '\xdfff'), arbitrary]
+
+prop_surrogateRoundtrip :: StringWithSurrogates -> Property
+prop_surrogateRoundtrip (StringWithSurrogates s) =
+    s === deserialise (serialise s)
+
+roundTrips :: (Eq a, Serialise a) => a -> Bool
+roundTrips x = x == deserialise (serialise x)
+
+testTree :: TestTree
+testTree =
+  testGroup "Issue 135 - surrogate characters round-trip"
+    [ testCase "simple reproduction case"   (True @=? all (\c -> c == deserialise (serialise c)) ['\xdc80'..'\xdcff'])
+    , testCase "all Chars round-trip" ([] @=? filter (not . roundTrips) ['\x0000'..'\x10ffff'])
+    , testProperty "surrogates round-trip" prop_surrogateRoundtrip
+    ]

--- a/serialise/tests/Tests/Serialise.hs
+++ b/serialise/tests/Tests/Serialise.hs
@@ -19,6 +19,7 @@ import           Data.List.NonEmpty ( NonEmpty )
 import qualified Data.Semigroup as Semigroup
 #endif
 
+import           Data.Char (ord)
 import           Data.Complex
 import           Data.Int
 import           Data.Fixed
@@ -297,7 +298,7 @@ testGenerics = testGroup "Format of Generics encoding"
       (TkListLen 3 $ TkWord 0 $ TkInt 12 $ TkFloat32 0.5 $ TkEnd)
   , format
       (P3 12 0.5 "asdf")
-      (TkListLen 4 $ TkWord 0 $ TkInt 12 $ TkFloat32 0.5 $ TkString "asdf" $ TkEnd)
+      (TkListLen 4 $ TkWord 0 $ TkInt 12 $ TkFloat32 0.5 $ tkStr "asdf" $ TkEnd)
   , format
       (C1 12)
       (TkListLen 2 $ TkWord 0 $ TkInt 12 $ TkEnd)
@@ -306,17 +307,19 @@ testGenerics = testGroup "Format of Generics encoding"
       (TkListLen 3 $ TkWord 1 $ TkInt 12 $ TkFloat32 0.5 $ TkEnd)
   , format
       (C3 12 0.5 "asdf")
-      (TkListLen 4 $ TkWord 2 $ TkInt 12 $ TkFloat32 0.5 $ TkString "asdf" $ TkEnd)
+      (TkListLen 4 $ TkWord 2 $ TkInt 12 $ TkFloat32 0.5 $ tkStr "asdf" $ TkEnd)
   , format
        C4
       (TkListLen 1 $ TkWord 3 $ TkEnd)
   , format
       (Cons "foo" (Cons "bar" Nil) :: List String)
-      (TkListLen 3 $ TkWord 0 $ TkString "foo" $
-       TkListLen 3 $ TkWord 0 $ TkString "bar" $
+      (TkListLen 3 $ TkWord 0 $ tkStr "foo" $
+       TkListLen 3 $ TkWord 0 $ tkStr "bar" $
        TkListLen 1 $ TkWord 1 $
        TkEnd)
   ]
+
+  where tkStr = TkUtf8ByteArray . fromList . map (fromIntegral . ord)
 
 --------------------------------------------------------------------------------
 -- Extra machinery


### PR DESCRIPTION
We scan the encoded characters during encoding looking for surrogates; if we
find any we encode the string as a a list of code-points encoded as words. This
is slow, but should be rare.

This fixes #135.