### PR TITLE
Read: Maintain no-empty-chunks invariant of lazy ByteString

### DIFF
--- a/cborg/src/Codec/CBOR/Read.hs
+++ b/cborg/src/Codec/CBOR/Read.hs
@@ -136,7 +136,10 @@ runIDecode d lbs =
        -> IDecode s a
        -> ST s (Either DeserialiseFailure (LBS.ByteString, ByteOffset, a))
     go  _                  (Fail _ _ err)  = return (Left err)
-    go  lbs'               (Done bs off x) = return (Right (LBS.Chunk bs lbs', off, x))
+    go  lbs'               (Done bs off x) = let rest
+                                                   | BS.null bs = lbs'
+                                                   | otherwise  = LBS.Chunk bs lbs'
+                                             in return (Right (rest, off, x))
     go  LBS.Empty          (Partial  k)    = k Nothing   >>= go LBS.Empty
     go (LBS.Chunk bs lbs') (Partial  k)    = k (Just bs) >>= go lbs'
 


### PR DESCRIPTION
`Data.ByteString.Lazy.ByteString` expects the invariant that no chunk is empty.
However, runIDecode was breaking this when producing the remaining
content. Fix this.