### PR TITLE
Fix compilation on x86_32

### DIFF
--- a/cborg/src/Codec/CBOR/ByteArray/Internal.hs
+++ b/cborg/src/Codec/CBOR/ByteArray/Internal.hs
@@ -72,9 +72,9 @@ mkByteArray n xs = runST $ do
 
 -- | A conservative estimate of pinned-ness.
 isByteArrayPinned :: Prim.ByteArray -> Bool
-isByteArrayPinned (Prim.ByteArray ba) =
+isByteArrayPinned (Prim.ByteArray _ba) =
 #if __GLASGOW_HASKELL__ > 800
-    case isByteArrayPinned# ba of
+    case isByteArrayPinned# _ba of
       0# -> False
       _  -> True
 #else

--- a/serialise/tests/Tests/Serialise.hs
+++ b/serialise/tests/Tests/Serialise.hs
@@ -218,7 +218,7 @@ testTree = testGroup "Serialise class"
       , mkTest (T :: T CUIntMax)
       , mkTest (T :: T CClock)
       , mkTest (T :: T CTime)
-      , mkTest (T :: T CUSeconds)
+      , mkTest (T :: T CUSeconds_)
       , mkTest (T :: T CSUSeconds)
       , mkTest (T :: T CFloat)
       , mkTest (T :: T CDouble)
@@ -334,6 +334,19 @@ mkTest t = testGroup ("type: " ++ show (typeOf (undefined :: a)))
   , testProperty "flat term is valid"  (prop_validFlatTerm t)
   ]
 
+--------------------------------------------------------------------------------
+-- Various data types
+
+-- Wrapper for CUSeconds with Arbitrary instance that works on x86_32.
+newtype CUSeconds_ = CUSeconds_ CUSeconds
+  deriving (Eq, Show, Typeable)
+
+instance Arbitrary CUSeconds_ where
+  arbitrary = CUSeconds_ . CUSeconds <$> arbitraryBoundedIntegral
+
+instance Serialise CUSeconds_ where
+  encode (CUSeconds_ s) = encode s
+  decode = CUSeconds_ <$> decode
 
 --------------------------------------------------------------------------------
 -- Generic data types


### PR DESCRIPTION
Fix for compilation of master on x86_32.

BTW, there is something fishy going on with QuickCheck there: see [test results](https://pastebin.com/NSJ8uJtc).

Apart from invalid time calculations, serialization of CUSeconds fails, but it seems that's a fault of buggy Arbitrary instance, as applying the following patch:

```diff
diff --git a/serialise/tests/Tests/Serialise.hs b/serialise/tests/Tests/Serialise.hs
index 8d75ae7..7ed8ac2 100644
--- a/serialise/tests/Tests/Serialise.hs
+++ b/serialise/tests/Tests/Serialise.hs
@@ -218,7 +218,7 @@ testTree = testGroup "Serialise class"
       , mkTest (T :: T CUIntMax)
       , mkTest (T :: T CClock)
       , mkTest (T :: T CTime)
-      , mkTest (T :: T CUSeconds)
+      , mkTest (T :: T CUSeconds_)
       , mkTest (T :: T CSUSeconds)
       , mkTest (T :: T CFloat)
       , mkTest (T :: T CDouble)
@@ -282,6 +282,16 @@ testTree = testGroup "Serialise class"
       ]
   ]
 
+newtype CUSeconds_ = CUSeconds_ CUSeconds
+  deriving (Typeable, Eq, Show)
+
+instance Serialise CUSeconds_ where
+  encode (CUSeconds_ s) = encode s
+  decode = CUSeconds_ <$> decode
+
+instance Arbitrary CUSeconds_ where
+  arbitrary = CUSeconds_ . CUSeconds <$> arbitraryBoundedIntegral
+
 testGenerics :: TestTree
 testGenerics = testGroup "Format of Generics encoding"
   [ format
```
fixes test failures.