### PR TITLE
Correct description in serialise.cabal

### DIFF
--- a/serialise/serialise.cabal
+++ b/serialise/serialise.cabal
@@ -11,7 +11,7 @@ description:
   Representation', or CBOR, specified in RFC 7049. As a result,
   serialised Haskell values have implicit structure outside of the
   Haskell program itself, meaning they can be inspected or analyzed
-  with custom tools.
+  without custom tools.
   .
   An implementation of the standard bijection between CBOR and JSON is provided
   by the [cborg-json](/package/cborg-json) package. Also see


### PR DESCRIPTION
Surely the point of using CBOR is that it can be parsed without needing custom tools (as with `binary`, for example)!