### PR TITLE
Add peekByteOffset primitive

### DIFF
--- a/cborg/cborg.cabal
+++ b/cborg/cborg.cabal
@@ -108,6 +108,7 @@ test-suite tests
   other-modules:
     Tests.CBOR
     Tests.Boundary
+    Tests.ByteOffset
     Tests.Regress
     Tests.Regress.Issue160
     Tests.Regress.Issue162

--- a/cborg/src/Codec/CBOR/Decoding.hs
+++ b/cborg/src/Codec/CBOR/Decoding.hs
@@ -71,6 +71,9 @@ module Codec.CBOR.Decoding
   , peekAvailable        -- :: Decoder s Int
   , TokenType(..)
 
+  -- ** Special operations
+  , ByteOffset
+
   -- ** Canonical CBOR
   -- $canonical
   , decodeWordCanonical      -- :: Decoder s Word
@@ -901,6 +904,15 @@ peekAvailable :: Decoder s Int
 peekAvailable = Decoder (\k -> return (PeekAvailable (\len# -> k (I# len#))))
 {-# INLINE peekAvailable #-}
 
+
+-- | A 0-based offset within the overall byte sequence that makes up the
+-- input to the 'Decoder'.
+--
+-- This is an 'Int64' since 'Decoder' is incremental and can decode more data
+-- than fits in memory at once. This is also compatible with the result type
+-- of 'Data.ByteString.Lazy.length'.
+--
+type ByteOffset = Int64
 {-
 expectExactly :: Word -> Decoder (Word :#: s) s
 expectExactly n = expectExactly_ n done

--- a/cborg/src/Codec/CBOR/Decoding.hs
+++ b/cborg/src/Codec/CBOR/Decoding.hs
@@ -68,11 +68,13 @@ module Codec.CBOR.Decoding
 
   -- ** Inspecting the token type
   , peekTokenType        -- :: Decoder s TokenType
-  , peekAvailable        -- :: Decoder s Int
   , TokenType(..)
 
   -- ** Special operations
+  , peekAvailable        -- :: Decoder s Int
   , ByteOffset
+  , peekByteOffset       -- :: Decoder s ByteOffset
+  , decodeWithByteSpan
 
   -- ** Canonical CBOR
   -- $canonical
@@ -103,12 +105,6 @@ module Codec.CBOR.Decoding
   , decodeSimpleCanonical  -- :: Decoder s Word8
   , decodeWordCanonicalOf    -- :: Word -> Decoder s ()
   , decodeListLenCanonicalOf -- :: Int  -> Decoder s ()
-
-{-
-  -- ** Special operations
-  , ignoreTerms
-  , decodeTrace
--}
 
   -- * Sequence operations
   , decodeSequenceLenIndef -- :: ...
@@ -222,6 +218,11 @@ data DecodeAction s a
 
     | PeekTokenType  (TokenType -> ST s (DecodeAction s a))
     | PeekAvailable  (Int#      -> ST s (DecodeAction s a))
+#if defined(ARCH_32bit)
+    | PeekByteOffset (Int64#    -> ST s (DecodeAction s a))
+#else
+    | PeekByteOffset (Int#      -> ST s (DecodeAction s a))
+#endif
 
     | Fail String
     | Done a
@@ -913,6 +914,38 @@ peekAvailable = Decoder (\k -> return (PeekAvailable (\len# -> k (I# len#))))
 -- of 'Data.ByteString.Lazy.length'.
 --
 type ByteOffset = Int64
+
+-- | Get the current 'ByteOffset' in the input byte sequence of the 'Decoder'.
+--
+-- The 'Decoder' does not provide any facility to get at the input data
+-- directly (since that is tricky with an incremental decoder). The next best
+-- is this primitive which can be used to keep track of the offset within the
+-- input bytes that makes up the encoded form of a term.
+--
+-- By keeping track of the byte offsets before and after decoding a subterm
+-- (a pattern captured by 'decodeWithByteSpan') and if the overall input data
+-- is retained then this is enables later retrieving the span of bytes for the
+-- subterm.
+--
+-- @since 0.2.2.0
+peekByteOffset :: Decoder s ByteOffset
+peekByteOffset = Decoder (\k -> return (PeekByteOffset (\off# -> k (I64# off#))))
+{-# INLINE peekByteOffset #-}
+
+-- | This captures the pattern of getting the byte offsets before and after
+-- decoding a subterm.
+--
+-- > !before <- peekByteOffset
+-- > x <- decode
+-- > !after  <- peekByteOffset
+--
+decodeWithByteSpan :: Decoder s a -> Decoder s (a, ByteOffset, ByteOffset)
+decodeWithByteSpan da = do
+    !before <- peekByteOffset
+    x <- da
+    !after  <- peekByteOffset
+    return (x, before, after)
+
 {-
 expectExactly :: Word -> Decoder (Word :#: s) s
 expectExactly n = expectExactly_ n done

--- a/cborg/src/Codec/CBOR/FlatTerm.hs
+++ b/cborg/src/Codec/CBOR/FlatTerm.hs
@@ -328,7 +328,15 @@ fromFlatTerm decoder ft =
 
     go ts@(tk:_) (PeekTokenType k) = k (tokenTypeOf tk) >>= go ts
     go ts        (PeekTokenType _) = unexpected "peekTokenType" ts
+
+    -- We don't have real bytes so we have to give these two operations
+    -- different interpretations: remaining tokens and just 0 for offsets.
     go ts        (PeekAvailable k) = k (unI# (length ts)) >>= go ts
+#if defined(ARCH_32bit)
+    go ts        (PeekByteOffset k)= k (unI64# 0) >>= go ts
+#else
+    go ts        (PeekByteOffset k)= k 0# >>= go ts
+#endif
 
     go _  (Fail msg) = return $ Left msg
     go [] (Done x)   = return $ Right x

--- a/cborg/src/Codec/CBOR/Read.hs
+++ b/cborg/src/Codec/CBOR/Read.hs
@@ -170,9 +170,6 @@ deserialiseIncremental decoder = do
 -- A monad for building incremental decoders
 --
 
--- | Simple alias for @'Int64'@, used to make types more descriptive.
-type ByteOffset = Int64
-
 newtype IncrementalDecoder s a = IncrementalDecoder {
        unIncrementalDecoder ::
          forall r. (a -> ST s (IDecode s r)) -> ST s (IDecode s r)

--- a/cborg/src/Codec/CBOR/Read.hs
+++ b/cborg/src/Codec/CBOR/Read.hs
@@ -242,6 +242,11 @@ data SlowPath s a
    | SlowConsumeTokenByteArray     {-# UNPACK #-} !ByteString (BA.ByteArray -> ST s (DecodeAction s a)) {-# UNPACK #-} !Int
    | SlowConsumeTokenString        {-# UNPACK #-} !ByteString (T.Text       -> ST s (DecodeAction s a)) {-# UNPACK #-} !Int
    | SlowConsumeTokenUtf8ByteArray {-# UNPACK #-} !ByteString (BA.ByteArray -> ST s (DecodeAction s a)) {-# UNPACK #-} !Int
+#if defined(ARCH_32bit)
+   | SlowPeekByteOffset            {-# UNPACK #-} !ByteString (Int64#       -> ST s (DecodeAction s a))
+#else
+   | SlowPeekByteOffset            {-# UNPACK #-} !ByteString (Int#         -> ST s (DecodeAction s a))
+#endif
    | SlowDecodeAction              {-# UNPACK #-} !ByteString (DecodeAction s a)
    | SlowFail                      {-# UNPACK #-} !ByteString String
 
@@ -697,6 +702,7 @@ go_fast !bs (PeekTokenType k) =
 
 go_fast !bs (PeekAvailable k) = k (case BS.length bs of I# len# -> len#) >>= go_fast bs
 
+go_fast !bs da@PeekByteOffset{} = go_fast_end bs da
 go_fast !bs da@D.Fail{} = go_fast_end bs da
 go_fast !bs da@D.Done{} = go_fast_end bs da
 
@@ -715,6 +721,8 @@ go_fast_end :: ByteString -> DecodeAction s a -> ST s (SlowPath s a)
 go_fast_end !bs (D.Fail msg)      = return $! SlowFail bs msg
 go_fast_end !bs (D.Done x)        = return $! FastDone bs x
 go_fast_end !bs (PeekAvailable k) = k (case BS.length bs of I# len# -> len#) >>= go_fast_end bs
+
+go_fast_end !bs (PeekByteOffset k) = return $! SlowPeekByteOffset bs k
 
 -- the next two cases only need the 1 byte token header
 go_fast_end !bs da | BS.null bs = return $! SlowDecodeAction bs da
@@ -1256,6 +1264,11 @@ go_slow da bs !offset = do
       where
         !offset' = offset + intToInt64 (BS.length bs - BS.length bs')
 
+    SlowPeekByteOffset bs' k ->
+      lift (k off#) >>= \daz -> go_slow daz bs' offset'
+      where
+        !offset'@(I64# off#) = offset + intToInt64 (BS.length bs - BS.length bs')
+
     SlowFail bs' msg -> decodeFail bs' offset' msg
       where
         !offset' = offset + intToInt64 (BS.length bs - BS.length bs')
@@ -1352,6 +1365,12 @@ go_slow_overlapped da sz bs_cur bs_next !offset =
         (bstr, bs'') <- getTokenShortOrVarLen bs' offset' len
         let !ba = BA.fromByteString bstr
         lift (k ba) >>= \daz -> go_slow daz bs'' (offset' + intToInt64 len)
+
+      SlowPeekByteOffset bs_empty k ->
+        assert (BS.null bs_empty) $ do
+        lift (k off#) >>= \daz -> go_slow daz bs' offset'
+        where
+          !(I64# off#) = offset'
 
       SlowFail bs_unconsumed msg ->
         decodeFail (bs_unconsumed <> bs') offset'' msg

--- a/cborg/tests/Main.hs
+++ b/cborg/tests/Main.hs
@@ -5,6 +5,7 @@ import           Test.Tasty (defaultMain, testGroup)
 
 import qualified Tests.CBOR      as CBOR
 import qualified Tests.Boundary  as Boundary
+import qualified Tests.ByteOffset as ByteOffset
 import qualified Tests.Regress   as Regress
 import qualified Tests.Reference as Reference
 import qualified Tests.UTF8      as UTF8
@@ -16,6 +17,7 @@ main =
   testGroup "CBOR tests"
     [ CBOR.testTree tcs
     , Reference.testTree tcs
+    , ByteOffset.testTree
     , Boundary.testTree
     , Regress.testTree
     , UTF8.testTree

--- a/cborg/tests/Tests/ByteOffset.hs
+++ b/cborg/tests/Tests/ByteOffset.hs
@@ -1,0 +1,459 @@
+{-# LANGUAGE DeriveFunctor, BangPatterns #-}
+
+module Tests.ByteOffset (testTree) where
+
+import           Data.Word
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as LT
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import           Control.Exception (throw)
+
+import           Codec.CBOR.Decoding
+import           Codec.CBOR.Read (deserialiseFromBytes)
+import           Codec.CBOR.Write (toLazyByteString)
+import           Codec.CBOR.Term (Term, encodeTerm, decodeTerm)
+import qualified Codec.CBOR.Term as Term (Term(..))
+
+import           Test.Tasty (TestTree, testGroup, localOption)
+import           Test.Tasty.QuickCheck (testProperty, QuickCheckMaxSize(..))
+import           Test.QuickCheck (Property, (==>))
+
+import qualified Tests.Reference.Implementation as RefImpl
+import           Tests.CBOR (eqTerm)
+import           Tests.Util
+
+import Prelude hiding (encodeFloat, decodeFloat)
+
+
+-- | Like a 'Term', but with an annotation on top level terms and every
+-- subterm. This is used for tests of 'peekByteOffset' where we annotate a
+-- decoded term with the byte range it covers.
+--
+data ATerm annotation = ATerm (TermF (ATerm annotation)) annotation
+  deriving (Show, Eq, Functor)
+
+-- | Term one-level functor.
+--
+data TermF t = TInt     Int
+             | TInteger Integer
+             | TBytes   BS.ByteString
+             | TBytesI  LBS.ByteString
+             | TString  T.Text
+             | TStringI LT.Text
+             | TList    [t]
+             | TListI   [t]
+             | TMap     [(t, t)]
+             | TMapI    [(t, t)]
+             | TTagged  Word64 t
+             | TBool    Bool
+             | TNull
+             | TSimple  Word8
+             | THalf    Float
+             | TFloat   Float
+             | TDouble  Double
+  deriving (Show, Eq, Functor)
+
+
+testTree :: TestTree
+testTree =
+  testGroup "peekByteOffset"
+    [ testGroup "ATerm framework"
+        [ testProperty "isomorphic 1" prop_ATerm_isomorphic
+        , testProperty "isomorphic 2" prop_ATerm_isomorphic2
+        , testProperty "isomorphic 3" prop_ATerm_isomorphic3
+        ]
+    , testProperty "bytes deserialise" prop_peekByteOffset_deserialise
+    , testProperty "bytes reserialise" prop_peekByteOffset_reserialise
+    , testProperty "non-canonical encoding" prop_peekByteOffset_noncanonical
+    , localOption (QuickCheckMaxSize 30) $
+      testProperty "same offsets with all 2-splits" prop_peekByteOffset_splits2
+    , localOption (QuickCheckMaxSize 20) $
+      testProperty "same offsets with all 3-splits" prop_peekByteOffset_splits3
+    ]
+
+
+--------------------------------------------------------------------------------
+-- Properties of the framework
+--
+
+-- | Basic property to check that 'ATerm' is isomorphic to the 'Term'.
+--
+prop_ATerm_isomorphic :: Term -> Bool
+prop_ATerm_isomorphic t =
+    t `eqTerm` (convertATermToTerm . convertTermToATerm) t
+    -- eqTerm is (==) modulo NaNs and overlapping Int vs Integer
+
+-- | Variation on 'prop_ATerm_isomorphic', checking that serialising as a
+-- 'Term', deserialising as an 'ATerm' and converting back gives an equivalent
+-- term.
+--
+prop_ATerm_isomorphic2 :: Term -> Bool
+prop_ATerm_isomorphic2 t =
+    t `eqTerm` (convertATermToTerm . deserialiseATerm . serialiseTerm) t
+    -- eqTerm is (==) modulo NaNs and overlapping Int vs Integer
+
+-- | Variation on 'prop_ATerm_isomorphic2', but where we check the terms are
+-- equivalent as 'ATerm's.
+--
+prop_ATerm_isomorphic3 :: Term -> Bool
+prop_ATerm_isomorphic3 t =
+            convertTermToATerm t
+  `eqATerm` (fmap (const ()) . deserialiseATerm . serialiseTerm) t
+
+
+--------------------------------------------------------------------------------
+-- Properties of peekByteOffset
+--
+
+-- | A key consistency property for terms annotated with their bytes:
+-- taking those bytes and deserialising them gives the corresponding term
+--
+prop_ATerm_deserialise :: ATerm ByteSpan -> Bool
+prop_ATerm_deserialise t@(ATerm _ bs) =
+    deserialiseTerm bs `eqTerm` convertATermToTerm t
+
+-- | For the case of canonical encodings it is also true for terms annotated
+-- with their bytes: taking the term and serialising it gives the bytes.
+--
+-- Note this is /only/ expected to hold for canonical encodings. See
+-- 'prop_peekByteOffset_noncanonical' for a demonstration of this not holding
+-- for non-canonical encodings.
+--
+prop_ATerm_reserialise :: ATerm ByteSpan -> Bool
+prop_ATerm_reserialise t@(ATerm _ bs) =
+    serialiseTerm (convertATermToTerm t) == bs
+
+-- | For an 'ATerm' annotated with its bytes (obtained by decoding a term),
+-- 'prop_ATerm_deserialise' should be true for the whole term and all subterms.
+--
+prop_peekByteOffset_deserialise :: Term -> Bool
+prop_peekByteOffset_deserialise t =
+    all prop_ATerm_deserialise (subterms t')
+  where
+    t' = deserialiseATerm (serialiseTerm t)
+
+-- | For an 'ATerm' annotated with its bytes (obtained by decoding a canonical
+-- term), 'prop_ATerm_serialise' should be true for the whole term and all
+-- subterms.
+--
+prop_peekByteOffset_reserialise :: Term -> Bool
+prop_peekByteOffset_reserialise t =
+    all prop_ATerm_reserialise (subterms t')
+  where
+    t' = deserialiseATerm (serialiseTerm t)
+
+-- | For an 'ATerm' annotated with its bytes obtained by decoding a
+-- /non-canonical/ term, 'prop_ATerm_serialise' should not always hold.
+--
+-- This is in some sense the essence of why we want 'peekByteOffset' in the
+-- first place: to get the bytes corresponding to a term we have to get the
+-- original input bytes since we cannot rely on re-serialising to recover the
+-- bytes (at least not without relying on and checking for canonical encodings).
+--
+prop_peekByteOffset_noncanonical :: RefImpl.Term -> Property
+prop_peekByteOffset_noncanonical t =
+    not (RefImpl.isCanonicalTerm t) ==>
+    not (prop_ATerm_reserialise t')
+  where
+    t' = deserialiseATerm (RefImpl.serialise t)
+
+-- | The offsets we get when decoding a term should be the same irrespective of
+-- block boundaries in the input data stream. This checks the property for all
+-- possible 2-chunk splits of the input data.
+--
+prop_peekByteOffset_splits2 :: Term -> Bool
+prop_peekByteOffset_splits2 t =
+    and [ deserialiseATermOffsets lbs' `eqATerm` t'
+        | lbs' <- splits2 lbs ]
+  where
+    lbs = serialiseTerm t
+    t'  = deserialiseATermOffsets lbs
+
+-- | The offsets we get when decoding a term should be the same irrespective of
+-- block boundaries in the input data stream. This checks the property for all
+-- possible 3-chunk splits of the input data.
+--
+prop_peekByteOffset_splits3 :: Term -> Bool
+prop_peekByteOffset_splits3 t =
+    and [ deserialiseATermOffsets lbs' `eqATerm` t'
+        | lbs' <- splits3 lbs ]
+  where
+    lbs = serialiseTerm t
+    t'  = deserialiseATermOffsets lbs
+
+
+------------------------------------------------------------------------------
+
+subterms :: ATerm a -> [ATerm a]
+subterms at@(ATerm t0 _) = at : subtermsF t0
+  where
+    subtermsF :: TermF (ATerm a) -> [ATerm a]
+    subtermsF (TList  ts)  = concatMap subterms ts
+    subtermsF (TListI ts)  = concatMap subterms ts
+    subtermsF (TMap   ts)  = [ t' | (x, y) <- ts
+                                 , t' <- subterms x
+                                      ++ subterms y ]
+    subtermsF (TMapI  ts)  = [ t' | (x, y) <- ts
+                                 , t' <- subterms x
+                                      ++ subterms y ]
+    subtermsF (TTagged _ t') = subterms t'
+
+    subtermsF TInt    {} = []
+    subtermsF TInteger{} = []
+    subtermsF TBytes  {} = []
+    subtermsF TBytesI {} = []
+    subtermsF TString {} = []
+    subtermsF TStringI{} = []
+    subtermsF TBool   {} = []
+    subtermsF TNull   {} = []
+    subtermsF TSimple {} = []
+    subtermsF THalf   {} = []
+    subtermsF TFloat  {} = []
+    subtermsF TDouble {} = []
+
+
+------------------------------------------------------------------------------
+
+serialiseTerm :: Term -> LBS.ByteString
+serialiseTerm = toLazyByteString . encodeTerm
+
+deserialiseTerm :: LBS.ByteString -> Term
+deserialiseTerm = either throw snd . deserialiseFromBytes decodeTerm
+
+
+--------------------------------------------------------------------------------
+-- Decoding a term, annotated with its underlying bytes
+--
+
+type Offsets  = (ByteOffset, ByteOffset)
+type ByteSpan = LBS.ByteString
+
+deserialiseATermOffsets :: LBS.ByteString -> ATerm Offsets
+deserialiseATermOffsets = either throw snd . deserialiseFromBytes decodeATerm
+
+deserialiseATerm :: LBS.ByteString -> ATerm ByteSpan
+deserialiseATerm lbs = atermOffsetsToBytes lbs (deserialiseATermOffsets lbs)
+
+atermOffsetsToBytes :: LBS.ByteString -> ATerm Offsets -> ATerm ByteSpan
+atermOffsetsToBytes original =
+    fmap (`slice` original)
+  where
+    slice :: (ByteOffset, ByteOffset) -> LBS.ByteString -> LBS.ByteString
+    slice (n,m) = LBS.take (m-n) . LBS.drop n
+
+
+decodeATerm :: Decoder s (ATerm Offsets)
+decodeATerm = do
+    start <- peekByteOffset
+    t     <- decodeTermFATerm
+    end   <- peekByteOffset
+    return (ATerm t (start, end))
+
+decodeTermFATerm :: Decoder s (TermF (ATerm Offsets))
+decodeTermFATerm = do
+    tkty <- peekTokenType
+    case tkty of
+      TypeUInt   -> do w <- decodeWord
+                       return $! fromWord w
+                    where
+                      fromWord :: Word -> TermF (ATerm Offsets)
+                      fromWord w
+                        | w <= fromIntegral (maxBound :: Int)
+                                    = TInt     (fromIntegral w)
+                        | otherwise = TInteger (fromIntegral w)
+
+      TypeUInt64 -> do w <- decodeWord64
+                       return $! fromWord64 w
+                    where
+                      fromWord64 w
+                        | w <= fromIntegral (maxBound :: Int)
+                                    = TInt     (fromIntegral w)
+                        | otherwise = TInteger (fromIntegral w)
+
+      TypeNInt   -> do w <- decodeNegWord
+                       return $! fromNegWord w
+                    where
+                      fromNegWord w
+                        | w <= fromIntegral (maxBound :: Int)
+                                    = TInt     (-1 - fromIntegral w)
+                        | otherwise = TInteger (-1 - fromIntegral w)
+
+      TypeNInt64 -> do w <- decodeNegWord64
+                       return $! fromNegWord64 w
+                    where
+                      fromNegWord64 w
+                        | w <= fromIntegral (maxBound :: Int)
+                                    = TInt     (-1 - fromIntegral w)
+                        | otherwise = TInteger (-1 - fromIntegral w)
+
+      TypeInteger -> do !x <- decodeInteger
+                        return (TInteger x)
+      TypeFloat16 -> do !x <- decodeFloat
+                        return (THalf x)
+      TypeFloat32 -> do !x <- decodeFloat
+                        return (TFloat x)
+      TypeFloat64 -> do !x <- decodeDouble
+                        return (TDouble x)
+
+      TypeBytes        -> do !x <- decodeBytes
+                             return (TBytes x)
+      TypeBytesIndef   -> decodeBytesIndef >> decodeBytesIndefLen []
+      TypeString       -> do !x <- decodeString
+                             return (TString x)
+      TypeStringIndef  -> decodeStringIndef >> decodeStringIndefLen []
+
+      TypeListLen      -> decodeListLen      >>= flip decodeListN []
+      TypeListLen64    -> decodeListLen      >>= flip decodeListN []
+      TypeListLenIndef -> decodeListLenIndef >>  decodeListIndefLen []
+      TypeMapLen       -> decodeMapLen       >>= flip decodeMapN []
+      TypeMapLen64     -> decodeMapLen       >>= flip decodeMapN []
+      TypeMapLenIndef  -> decodeMapLenIndef  >>  decodeMapIndefLen []
+      TypeTag          -> do !x <- decodeTag64
+                             !y <- decodeATerm
+                             return (TTagged x y)
+      TypeTag64        -> do !x <- decodeTag64
+                             !y <- decodeATerm
+                             return (TTagged x y)
+
+      TypeBool    -> do !x <- decodeBool
+                        return (TBool x)
+      TypeNull    -> TNull   <$  decodeNull
+      TypeSimple  -> do !x <- decodeSimple
+                        return (TSimple x)
+      TypeBreak   -> fail "unexpected break"
+      TypeInvalid -> fail "invalid token encoding"
+
+
+decodeBytesIndefLen :: [BS.ByteString] -> Decoder s (TermF (ATerm Offsets))
+decodeBytesIndefLen acc = do
+    stop <- decodeBreakOr
+    if stop then return $! TBytesI (LBS.fromChunks (reverse acc))
+            else do !bs <- decodeBytes
+                    decodeBytesIndefLen (bs : acc)
+
+
+decodeStringIndefLen :: [T.Text] -> Decoder s (TermF (ATerm Offsets))
+decodeStringIndefLen acc = do
+    stop <- decodeBreakOr
+    if stop then return $! TStringI (LT.fromChunks (reverse acc))
+            else do !str <- decodeString
+                    decodeStringIndefLen (str : acc)
+
+
+decodeListN :: Int -> [ATerm Offsets] -> Decoder s (TermF (ATerm Offsets))
+decodeListN !n acc =
+    case n of
+      0 -> return $! TList (reverse acc)
+      _ -> do !t <- decodeATerm
+              decodeListN (n-1) (t : acc)
+
+
+decodeListIndefLen :: [ATerm Offsets] -> Decoder s (TermF (ATerm Offsets))
+decodeListIndefLen acc = do
+    stop <- decodeBreakOr
+    if stop then return $! TListI (reverse acc)
+            else do !tm <- decodeATerm
+                    decodeListIndefLen (tm : acc)
+
+
+decodeMapN :: Int -> [(ATerm Offsets, ATerm Offsets)] -> Decoder s (TermF (ATerm Offsets))
+decodeMapN !n acc =
+    case n of
+      0 -> return $! TMap (reverse acc)
+      _ -> do !tm   <- decodeATerm
+              !tm'  <- decodeATerm
+              decodeMapN (n-1) ((tm, tm') : acc)
+
+
+decodeMapIndefLen :: [(ATerm Offsets, ATerm Offsets)] -> Decoder s (TermF (ATerm Offsets))
+decodeMapIndefLen acc = do
+    stop <- decodeBreakOr
+    if stop then return $! TMapI (reverse acc)
+            else do !tm  <- decodeATerm
+                    !tm' <- decodeATerm
+                    decodeMapIndefLen ((tm, tm') : acc)
+
+
+--------------------------------------------------------------------------------
+-- Converting between terms and annotated terms
+
+
+convertTermToATerm :: Term -> ATerm ()
+convertTermToATerm t = ATerm (convertTermToTermF t) ()
+
+convertTermToTermF :: Term -> TermF (ATerm ())
+convertTermToTermF (Term.TList   ts)  = TList  (map convertTermToATerm ts)
+convertTermToTermF (Term.TListI  ts)  = TListI (map convertTermToATerm ts)
+convertTermToTermF (Term.TMap    ts)  = TMap  [ ( convertTermToATerm x
+                                                , convertTermToATerm y )
+                                              | (x, y) <- ts ]
+convertTermToTermF (Term.TMapI   ts)  = TMapI [ ( convertTermToATerm x
+                                                , convertTermToATerm y )
+                                              | (x, y) <- ts ]
+convertTermToTermF (Term.TTagged x t) = TTagged x (convertTermToATerm t)
+
+convertTermToTermF (Term.TInt     x)  = TInt   x
+convertTermToTermF (Term.TInteger x)  = TInteger x
+convertTermToTermF (Term.TBytes   x)  = TBytes  x
+convertTermToTermF (Term.TBytesI  x)  = TBytesI x
+convertTermToTermF (Term.TString  x)  = TString  x
+convertTermToTermF (Term.TStringI x)  = TStringI x
+convertTermToTermF (Term.TBool    x)  = TBool x
+convertTermToTermF  Term.TNull        = TNull
+convertTermToTermF (Term.TSimple  x)  = TSimple x
+convertTermToTermF (Term.THalf    x)  = THalf x
+convertTermToTermF (Term.TFloat   x)  = TFloat x
+convertTermToTermF (Term.TDouble  x)  = TDouble x
+
+convertATermToTerm :: ATerm a -> Term
+convertATermToTerm (ATerm t _ann) = convertTermFToTerm t
+
+convertTermFToTerm :: TermF (ATerm a) -> Term
+convertTermFToTerm (TList   ts)  = Term.TList  (map convertATermToTerm ts)
+convertTermFToTerm (TListI  ts)  = Term.TListI (map convertATermToTerm ts)
+convertTermFToTerm (TMap    ts)  = Term.TMap  [ ( convertATermToTerm x
+                                                , convertATermToTerm y )
+                                              | (x, y) <- ts ]
+convertTermFToTerm (TMapI   ts)  = Term.TMapI [ ( convertATermToTerm x
+                                                , convertATermToTerm y )
+                                              | (x, y) <- ts ]
+convertTermFToTerm (TTagged x t) = Term.TTagged  x (convertATermToTerm t)
+convertTermFToTerm (TInt     x)  = Term.TInt     x
+convertTermFToTerm (TInteger x)  = Term.TInteger x
+convertTermFToTerm (TBytes   x)  = Term.TBytes   x
+convertTermFToTerm (TBytesI  x)  = Term.TBytesI  x
+convertTermFToTerm (TString  x)  = Term.TString  x
+convertTermFToTerm (TStringI x)  = Term.TStringI x
+convertTermFToTerm (TBool    x)  = Term.TBool    x
+convertTermFToTerm  TNull        = Term.TNull
+convertTermFToTerm (TSimple  x)  = Term.TSimple  x
+convertTermFToTerm (THalf    x)  = Term.THalf    x
+convertTermFToTerm (TFloat   x)  = Term.TFloat   x
+convertTermFToTerm (TDouble  x)  = Term.TDouble  x
+
+
+-- NaNs are so annoying...
+eqATerm :: Eq a => ATerm a -> ATerm a -> Bool
+eqATerm (ATerm t1 ann1) (ATerm t2 ann2) =
+    ann1 == ann2 && eqATermF t1 t2
+
+eqATermF :: Eq a => TermF (ATerm a) -> TermF (ATerm a) -> Bool
+eqATermF (TInt    n)   (TInteger n')   = fromIntegral n == n'
+eqATermF (TInteger n)  (TInt     n')   = n == fromIntegral n'
+eqATermF (TList   ts)  (TList   ts')   = and (zipWith eqATerm ts ts')
+eqATermF (TListI  ts)  (TListI  ts')   = and (zipWith eqATerm ts ts')
+eqATermF (TMap    ts)  (TMap    ts')   = and (zipWith eqATermPair ts ts')
+eqATermF (TMapI   ts)  (TMapI   ts')   = and (zipWith eqATermPair ts ts')
+eqATermF (TTagged w t) (TTagged w' t') = w == w' && eqATerm t t'
+eqATermF (THalf   f)   (THalf   f') | isNaN f && isNaN f' = True
+eqATermF (TFloat  f)   (TFloat  f') | isNaN f && isNaN f' = True
+eqATermF (TDouble f)   (TDouble f') | isNaN f && isNaN f' = True
+eqATermF a b = a == b
+
+eqATermPair :: (Eq a, Eq b)
+              => (ATerm a, ATerm b)
+              -> (ATerm a, ATerm b)
+              -> Bool
+eqATermPair (a,b) (a',b') = eqATerm a a' && eqATerm b b'
+

--- a/cborg/tests/Tests/CBOR.hs
+++ b/cborg/tests/Tests/CBOR.hs
@@ -4,6 +4,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Tests.CBOR
   ( testTree -- :: TestTree
+  , eqTerm
   ) where
 
 import qualified Data.ByteString      as BS
@@ -193,7 +194,8 @@ fromRefTerm (RefImpl.TFloat64 f) = if isNaN f
 
 -- NaNs are so annoying...
 eqTerm :: Term -> Term -> Bool
-eqTerm (TInt    n)   (TInteger n')   = fromIntegral n == n'
+eqTerm (TInt     n)  (TInteger n')   = fromIntegral n == n'
+eqTerm (TInteger n)  (TInt     n')   = n == fromIntegral n'
 eqTerm (TList   ts)  (TList   ts')   = and (zipWith eqTerm ts ts')
 eqTerm (TListI  ts)  (TListI  ts')   = and (zipWith eqTerm ts ts')
 eqTerm (TMap    ts)  (TMap    ts')   = and (zipWith eqTermPair ts ts')

--- a/cborg/tests/Tests/Reference/Implementation.hs
+++ b/cborg/tests/Tests/Reference/Implementation.hs
@@ -24,6 +24,7 @@ module Tests.Reference.Implementation (
     reservedSimple,
     eqTerm,
     canonicaliseTerm,
+    isCanonicalTerm,
 
     UInt(..),
     fromUInt,
@@ -811,6 +812,9 @@ eqTerm a b = a == b
 
 eqTermPair :: (Term, Term) -> (Term, Term) -> Bool
 eqTermPair (a,b) (a',b') = eqTerm a a' && eqTerm b b'
+
+isCanonicalTerm :: Term -> Bool
+isCanonicalTerm t = canonicaliseTerm t == t
 
 canonicaliseTerm :: Term -> Term
 canonicaliseTerm (TUInt n) = TUInt (canonicaliseUInt n)


### PR DESCRIPTION
Get the current `ByteOffset` in the input byte sequence of the Decoder. The Decoder does not provide any facility to get at the input data directly (since that is tricky with an incremental decoder). The next best is this primitive which can be used to keep track of the offset within the input bytes that makes up the encoded form of a term.

By keeping track of the byte offsets before and after decoding a subterm (a pattern captured by `decodeWithByteSpan`) and if the overall input data is retained then this is enables later retrieving the span of bytes for the subterm.

This includes tests. The main property we test is that if we decode a Term where we track the byte span of the whole term and all sub-terms then the bytes we get do indeed deserialise to the same sub-term, or reserialising the term gives us the bytes. Overall this tells us that we must be getting the byte offsets right.