### PR TITLE
Major testsuite improvements, including canonical form tests

### DIFF
--- a/cborg/cborg.cabal
+++ b/cborg/cborg.cabal
@@ -115,6 +115,7 @@ test-suite tests
     Tests.Regress.FlatTerm
     Tests.Reference
     Tests.Reference.Implementation
+    Tests.Reference.Generators
     Tests.Reference.TestVectors
     Tests.UTF8
     Tests.Util

--- a/cborg/cborg.cabal
+++ b/cborg/cborg.cabal
@@ -106,7 +106,8 @@ test-suite tests
     -threaded -rtsopts "-with-rtsopts=-N2"
 
   other-modules:
-    Tests.CBOR
+    Tests.UnitTests
+    Tests.Properties
     Tests.Boundary
     Tests.ByteOffset
     Tests.Regress
@@ -117,6 +118,7 @@ test-suite tests
     Tests.Reference.Implementation
     Tests.Reference.Generators
     Tests.Reference.TestVectors
+    Tests.Term
     Tests.UTF8
     Tests.Util
 

--- a/cborg/cborg.cabal
+++ b/cborg/cborg.cabal
@@ -110,6 +110,7 @@ test-suite tests
     Tests.Properties
     Tests.Boundary
     Tests.ByteOffset
+    Tests.Canonical
     Tests.Regress
     Tests.Regress.Issue160
     Tests.Regress.Issue162

--- a/cborg/cborg.cabal
+++ b/cborg/cborg.cabal
@@ -133,6 +133,7 @@ test-suite tests
     fail                    >= 4.9.0.0 && < 4.10,
     half                    >= 0.2.2.3 && < 0.4,
     QuickCheck              >= 2.9     && < 2.13,
+    random,
     scientific              >= 0.3     && < 0.4,
     tasty                   >= 0.11    && < 1.2,
     tasty-hunit             >= 0.9     && < 0.11,

--- a/cborg/tests/Main.hs
+++ b/cborg/tests/Main.hs
@@ -3,7 +3,8 @@ module Main (main) where
 import           Test.Tasty (TestTree, defaultMain, testGroup)
 
 import qualified Tests.Reference  as Reference
-import qualified Tests.CBOR       as CBOR
+import qualified Tests.UnitTests  as UnitTests
+import qualified Tests.Properties as Properties
 import qualified Tests.Boundary   as Boundary
 import qualified Tests.ByteOffset as ByteOffset
 import qualified Tests.Regress    as Regress
@@ -16,7 +17,8 @@ tests :: TestTree
 tests =
   testGroup "CBOR"
     [ Reference.testTree
-    , CBOR.testTree
+    , UnitTests.testTree
+    , Properties.testTree
     , ByteOffset.testTree
     , Boundary.testTree
     , Regress.testTree

--- a/cborg/tests/Main.hs
+++ b/cborg/tests/Main.hs
@@ -7,6 +7,7 @@ import qualified Tests.UnitTests  as UnitTests
 import qualified Tests.Properties as Properties
 import qualified Tests.Boundary   as Boundary
 import qualified Tests.ByteOffset as ByteOffset
+import qualified Tests.Canonical  as Canonical
 import qualified Tests.Regress    as Regress
 import qualified Tests.UTF8       as UTF8
 
@@ -21,6 +22,7 @@ tests =
     , Properties.testTree
     , ByteOffset.testTree
     , Boundary.testTree
+    , Canonical.testTree
     , Regress.testTree
     , UTF8.testTree
     ]

--- a/cborg/tests/Tests/ByteOffset.hs
+++ b/cborg/tests/Tests/ByteOffset.hs
@@ -450,6 +450,10 @@ eqATermF (TTagged w t) (TTagged w' t') = w == w' && eqATerm t t'
 eqATermF (THalf   f)   (THalf   f') | isNaN f && isNaN f' = True
 eqATermF (TFloat  f)   (TFloat  f') | isNaN f && isNaN f' = True
 eqATermF (TDouble f)   (TDouble f') | isNaN f && isNaN f' = True
+eqATermF (THalf   f)   (TFloat  f') | isNaN f && isNaN f' = True
+eqATermF (THalf   f)   (TDouble f') | isNaN f && isNaN f' = True
+eqATermF (TFloat  f)   (THalf   f') | isNaN f && isNaN f' = True
+eqATermF (TDouble f)   (THalf   f') | isNaN f && isNaN f' = True
 eqATermF a b = a == b
 
 eqATermPair :: (Eq a, Eq b)

--- a/cborg/tests/Tests/ByteOffset.hs
+++ b/cborg/tests/Tests/ByteOffset.hs
@@ -22,7 +22,7 @@ import           Test.QuickCheck hiding (subterms)
 
 import qualified Tests.Reference.Implementation as RefImpl
 import           Tests.Reference.Generators (floatToWord, doubleToWord)
-import           Tests.CBOR (eqTerm, canonicaliseTermNaNs, canonicaliseTermIntegers)
+import           Tests.Term (eqTerm, canonicaliseTermNaNs, canonicaliseTermIntegers)
 import           Tests.Util
 
 import Prelude hiding (encodeFloat, decodeFloat)

--- a/cborg/tests/Tests/ByteOffset.hs
+++ b/cborg/tests/Tests/ByteOffset.hs
@@ -22,7 +22,7 @@ import           Test.QuickCheck hiding (subterms)
 
 import qualified Tests.Reference.Implementation as RefImpl
 import           Tests.Reference.Generators (floatToWord, doubleToWord)
-import           Tests.Term (eqTerm, canonicaliseTermNaNs, canonicaliseTermIntegers)
+import           Tests.Term (eqTerm, canonicaliseTerm)
 import           Tests.Util
 
 import Prelude hiding (encodeFloat, decodeFloat)
@@ -91,7 +91,7 @@ prop_ATerm_isomorphic t =
 --
 prop_ATerm_isomorphic2 :: Term -> Bool
 prop_ATerm_isomorphic2 t =
-           (canonicaliseTermNaNs . canonicaliseTermIntegers) t
+           canonicaliseTerm t
   `eqTerm` (convertATermToTerm . deserialiseATerm . serialiseTerm) t
 
 -- | Variation on 'prop_ATerm_isomorphic2', but where we check the terms are
@@ -99,8 +99,7 @@ prop_ATerm_isomorphic2 t =
 --
 prop_ATerm_isomorphic3 :: Term -> Bool
 prop_ATerm_isomorphic3 t =
-            (convertTermToATerm . canonicaliseTermNaNs
-                                . canonicaliseTermIntegers) t
+            (convertTermToATerm . canonicaliseTerm) t
   `eqATerm` (fmap (const ()) . deserialiseATerm . serialiseTerm) t
 
 

--- a/cborg/tests/Tests/ByteOffset.hs
+++ b/cborg/tests/Tests/ByteOffset.hs
@@ -18,7 +18,7 @@ import qualified Codec.CBOR.Term as Term (Term(..))
 
 import           Test.Tasty (TestTree, testGroup, localOption)
 import           Test.Tasty.QuickCheck (testProperty, QuickCheckMaxSize(..))
-import           Test.QuickCheck (Property, (==>))
+import           Test.QuickCheck hiding (subterms)
 
 import qualified Tests.Reference.Implementation as RefImpl
 import           Tests.CBOR (eqTerm)

--- a/cborg/tests/Tests/CBOR.hs
+++ b/cborg/tests/Tests/CBOR.hs
@@ -18,11 +18,12 @@ import           Codec.CBOR.Term
 import           Codec.CBOR.Read
 import           Codec.CBOR.Write
 
-import           Test.Tasty
-import           Test.Tasty.HUnit
-import           Test.Tasty.QuickCheck
+import           Test.Tasty (TestTree, testGroup, localOption)
+import           Test.Tasty.HUnit (Assertion, testCase, assertEqual, (@=?))
+import           Test.Tasty.QuickCheck (testProperty, QuickCheckMaxSize(..))
+import           Test.QuickCheck
 
-import qualified Tests.Reference.Implementation  as RefImpl
+import qualified Tests.Reference.Implementation as RefImpl
 import           Tests.Reference.TestVectors
 import           Tests.Reference (termToJson, equalJson)
 import           Tests.Util
@@ -280,8 +281,8 @@ instance Arbitrary Term where
   shrink (TMapI xys@[(x,y)]) = x : y : [ TMapI xys' | xys' <- shrink xys ]
   shrink (TMapI xys)         =         [ TMapI xys' | xys' <- shrink xys ]
 
-  shrink (TTagged w t) = [ TTagged w' t' | (w', t') <- shrink (w, t)
-                         , not (RefImpl.reservedTag (fromIntegral w')) ]
+  shrink (TTagged w t) = t : [ TTagged w' t' | (w', t') <- shrink (w, t)
+                             , not (RefImpl.reservedTag (fromIntegral w')) ]
 
   shrink (TBool _) = []
   shrink TNull  = []

--- a/cborg/tests/Tests/CBOR.hs
+++ b/cborg/tests/Tests/CBOR.hs
@@ -225,12 +225,8 @@ fromRefTerm  RefImpl.TNull       = TNull
 fromRefTerm  RefImpl.TUndef      = TSimple 23
 fromRefTerm (RefImpl.TSimple  w) = TSimple w
 fromRefTerm (RefImpl.TFloat16 f) = THalf (Half.fromHalf f)
-fromRefTerm (RefImpl.TFloat32 f) = if isNaN f
-                                   then THalf (Half.fromHalf RefImpl.canonicalNaN)
-                                   else TFloat f
-fromRefTerm (RefImpl.TFloat64 f) = if isNaN f
-                                   then THalf (Half.fromHalf RefImpl.canonicalNaN)
-                                   else TDouble f
+fromRefTerm (RefImpl.TFloat32 f) = TFloat f
+fromRefTerm (RefImpl.TFloat64 f) = TDouble f
 
 -- NaNs are so annoying...
 eqTerm :: Term -> Term -> Bool
@@ -244,6 +240,10 @@ eqTerm (TTagged w t) (TTagged w' t') = w == w' && eqTerm t t'
 eqTerm (THalf   f)   (THalf   f') | isNaN f && isNaN f' = True
 eqTerm (TFloat  f)   (TFloat  f') | isNaN f && isNaN f' = True
 eqTerm (TDouble f)   (TDouble f') | isNaN f && isNaN f' = True
+eqTerm (THalf   f)   (TFloat  f') | isNaN f && isNaN f' = True
+eqTerm (THalf   f)   (TDouble f') | isNaN f && isNaN f' = True
+eqTerm (TFloat  f)   (THalf   f') | isNaN f && isNaN f' = True
+eqTerm (TDouble f)   (THalf   f') | isNaN f && isNaN f' = True
 eqTerm a b = a == b
 
 eqTermPair :: (Term, Term) -> (Term, Term) -> Bool

--- a/cborg/tests/Tests/Canonical.hs
+++ b/cborg/tests/Tests/Canonical.hs
@@ -1,0 +1,191 @@
+{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE AllowAmbiguousTypes  #-}
+{-# LANGUAGE TypeApplications     #-}
+
+module Tests.Canonical (testTree) where
+
+import           Prelude hiding (decodeFloat, encodeFloat)
+
+#if !MIN_VERSION_base(4,8,0)
+import           Control.Applicative
+#endif
+
+import qualified Data.ByteString.Lazy as LBS
+
+import           Codec.CBOR.Read (deserialiseFromBytes)
+import           Codec.CBOR.Decoding
+
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+import           Test.QuickCheck
+
+import           Tests.Properties hiding (testTree)
+
+
+-- | This is a version of 'prop_decodeRefdecodeImp' but where we restrict the
+-- encoded input to non-canonical forms. These forms are covered by the
+-- original property. This property just ensures that we have good coverage of
+-- this case.
+--
+prop_decodeRefdecodeImp_NonCanonical :: forall t. Token t => t -> Property
+prop_decodeRefdecodeImp_NonCanonical x =
+    let enc  = serialiseRef x
+        y    = deserialiseRef @t enc
+        y'   = deserialiseImp @t enc
+        enc' = serialiseImp @t y'
+        isCanonical = enc == enc'
+     in not isCanonical ==>
+        -- This property holds without this pre-condition, as demonstrated by
+        -- prop_decodeRefdecodeImp, but using it ensures we get good coverage
+        -- of the non-canonical cases
+        y' `eq` fromRef y
+
+  where
+    eq = eqImp @t
+
+
+-- | Check that the special checked canonical form decoder primitives work.
+--
+-- We decode with the normal and canonical decoder, and check that they agree
+-- in the canonical cases, and that the canonical decoder rejects the
+-- non-canonical cases.
+--
+-- We have a QC coverage check to make sure we are covering enough of both
+-- canonical and non-canonical cases.
+--
+prop_decodeCanonical :: forall t. Token t
+                     => (forall s. Decoder s (Imp t))
+                     -> t -> Property
+prop_decodeCanonical decodeCanonical x =
+    classify isCanonical "canonical" $
+    case deserialiseFromBytes decodeCanonical enc of
+      Left  _failure       -> not isCanonical
+      Right (trailing, y') ->     isCanonical
+                               && eqImp @t y y'
+                               && LBS.null trailing
+  where
+    enc = serialiseRef x
+    y   = deserialiseImp @t enc
+    -- It is canonical if it re-encodes to the same bytes we decoded
+    isCanonical = serialiseImp @t y == enc
+
+
+
+prop_decodeCanonical_Word :: TokWord -> Property
+prop_decodeCanonical_Word = prop_decodeCanonical decodeWordCanonical
+
+prop_decodeCanonical_Word8 :: TokWord8 -> Property
+prop_decodeCanonical_Word8 = prop_decodeCanonical decodeWord8Canonical
+
+prop_decodeCanonical_Word16 :: TokWord16 -> Property
+prop_decodeCanonical_Word16 = prop_decodeCanonical decodeWord16Canonical
+
+prop_decodeCanonical_Word32 :: TokWord32 -> Property
+prop_decodeCanonical_Word32 = prop_decodeCanonical decodeWord32Canonical
+
+prop_decodeCanonical_Word64 :: TokWord64 -> Property
+prop_decodeCanonical_Word64 = prop_decodeCanonical decodeWord64Canonical
+
+--prop_decodeCanonical_NegWord :: TokNegWord -> Property
+--prop_decodeCanonical_NegWord = prop_decodeCanonical decodeNegWordCanonical
+
+prop_decodeCanonical_Int :: TokInt -> Property
+prop_decodeCanonical_Int = prop_decodeCanonical decodeIntCanonical
+
+prop_decodeCanonical_Int8 :: TokInt8 -> Property
+prop_decodeCanonical_Int8 = prop_decodeCanonical decodeInt8Canonical
+
+prop_decodeCanonical_Int16 :: TokInt16 -> Property
+prop_decodeCanonical_Int16 = prop_decodeCanonical decodeInt16Canonical
+
+prop_decodeCanonical_Int32 :: TokInt32 -> Property
+prop_decodeCanonical_Int32 = prop_decodeCanonical decodeInt32Canonical
+
+prop_decodeCanonical_Int64 :: TokInt64 -> Property
+prop_decodeCanonical_Int64 = prop_decodeCanonical decodeInt64Canonical
+
+prop_decodeCanonical_Integer :: TokInteger -> Property
+prop_decodeCanonical_Integer = prop_decodeCanonical decodeIntegerCanonical
+
+prop_decodeCanonical_Half :: TokHalf -> Property
+prop_decodeCanonical_Half = prop_decodeCanonical decodeFloat16Canonical
+
+prop_decodeCanonical_Float :: TokFloat -> Property
+prop_decodeCanonical_Float = prop_decodeCanonical decodeFloatCanonical
+
+prop_decodeCanonical_Double :: TokDouble -> Property
+prop_decodeCanonical_Double = prop_decodeCanonical decodeDoubleCanonical
+
+prop_decodeCanonical_Tag :: TokTag -> Property
+prop_decodeCanonical_Tag = prop_decodeCanonical decodeTagCanonical
+
+prop_decodeCanonical_Tag64 :: TokTag64 -> Property
+prop_decodeCanonical_Tag64 = prop_decodeCanonical decodeTag64Canonical
+
+prop_decodeCanonical_Simple :: Simple -> Property
+prop_decodeCanonical_Simple = prop_decodeCanonical decodeSimpleCanonical
+
+
+{-
+  , decodeNegWordCanonical   -- :: Decoder s Word
+  , decodeNegWord64Canonical -- :: Decoder s Word64
+  , decodeBytesCanonical -- :: Decoder s ByteString
+  , decodeByteArrayCanonical -- :: Decoder s ByteArray
+  , decodeStringCanonical -- :: Decoder s Text
+  , decodeUtf8ByteArrayCanonical -- :: Decoder s ByteArray
+  , decodeListLenCanonical -- :: Decoder s Int
+  , decodeMapLenCanonical -- :: Decoder s Int
+-}
+
+--------------------------------------------------------------------------------
+-- TestTree API
+
+testTree :: TestTree
+testTree =
+  testGroup "properties"
+  [ testGroup "decode non-canonical encoding"
+    [ testProperty "Word8"   (prop_decodeRefdecodeImp_NonCanonical @ TokWord8)
+    , testProperty "Word16"  (prop_decodeRefdecodeImp_NonCanonical @ TokWord16)
+    , testProperty "Word32"  (prop_decodeRefdecodeImp_NonCanonical @ TokWord32)
+    , testProperty "Word64"  (prop_decodeRefdecodeImp_NonCanonical @ TokWord64)
+    , testProperty "Word"    (prop_decodeRefdecodeImp_NonCanonical @ TokWord)
+--  , testProperty "NegWord" (prop_decodeRefdecodeImp_NonCanonical @ TokNegWord)
+    , testProperty "Int8"    (prop_decodeRefdecodeImp_NonCanonical @ TokInt8)
+    , testProperty "Int16"   (prop_decodeRefdecodeImp_NonCanonical @ TokInt16)
+    , testProperty "Int32"   (prop_decodeRefdecodeImp_NonCanonical @ TokInt32)
+    , testProperty "Int64"   (prop_decodeRefdecodeImp_NonCanonical @ TokInt64)
+    , testProperty "Int"     (prop_decodeRefdecodeImp_NonCanonical @ TokInt)
+    , testProperty "Integer" (prop_decodeRefdecodeImp_NonCanonical @ TokInteger)
+    , testProperty "Half"    (prop_decodeRefdecodeImp_NonCanonical @ TokHalf)
+    , testProperty "Float"   (prop_decodeRefdecodeImp_NonCanonical @ TokFloat)
+    , testProperty "Double"  (prop_decodeRefdecodeImp_NonCanonical @ TokDouble)
+    , testProperty "Tag"     (prop_decodeRefdecodeImp_NonCanonical @ TokTag)
+    , testProperty "Tag64"   (prop_decodeRefdecodeImp_NonCanonical @ TokTag64)
+    , testProperty "Simple"  (prop_decodeRefdecodeImp_NonCanonical @ Simple)
+    , testProperty "Term"    (prop_decodeRefdecodeImp_NonCanonical @ Term)
+    ]
+
+  , testGroup "canonical decoding"
+    [ testProperty "Word"     prop_decodeCanonical_Word
+    , testProperty "Word8"    prop_decodeCanonical_Word8
+    , testProperty "Word16"   prop_decodeCanonical_Word16
+    , testProperty "Word32"   prop_decodeCanonical_Word32
+    , testProperty "Word64"   prop_decodeCanonical_Word64
+    , testProperty "Int"      prop_decodeCanonical_Int
+    , testProperty "Int8"     prop_decodeCanonical_Int8
+    , testProperty "Int16"    prop_decodeCanonical_Int16
+    , testProperty "Int32"    prop_decodeCanonical_Int32
+    , testProperty "Int64"    prop_decodeCanonical_Int64
+    , testProperty "Integer"  prop_decodeCanonical_Integer
+    , testProperty "Half"     prop_decodeCanonical_Half
+    , testProperty "Float"    prop_decodeCanonical_Float
+    , testProperty "Double"   prop_decodeCanonical_Double
+    , testProperty "Tag"      prop_decodeCanonical_Tag
+    , testProperty "Tag64"    prop_decodeCanonical_Tag64
+    , testProperty "Simple"   prop_decodeCanonical_Simple
+    ]
+  ]
+

--- a/cborg/tests/Tests/Properties.hs
+++ b/cborg/tests/Tests/Properties.hs
@@ -12,11 +12,11 @@ import           Test.Tasty (TestTree, testGroup, localOption)
 import           Test.Tasty.QuickCheck (testProperty, QuickCheckMaxSize(..))
 import           Test.QuickCheck
 
-import qualified Tests.Reference.Implementation as RefImpl
+import qualified Tests.Reference.Implementation as Ref
+import qualified Tests.Term as Term (serialise, deserialise)
 import           Tests.Term
                    ( fromRefTerm, toRefTerm, eqTerm
                    , prop_toFromRefTerm, prop_fromToRefTerm
-                   , serialise, deserialise
                    , canonicaliseTermNaNs, canonicaliseTermIntegers )
 import           Tests.Util
 
@@ -31,48 +31,48 @@ import           Control.Applicative
 
 prop_encodeDecodeTermRoundtrip :: Term -> Bool
 prop_encodeDecodeTermRoundtrip term =
-             (deserialise . serialise) term
+             (Term.deserialise . Term.serialise) term
     `eqTerm` (canonicaliseTermNaNs . canonicaliseTermIntegers) term
 
 prop_encodeDecodeTermRoundtrip_splits2 :: Term -> Bool
 prop_encodeDecodeTermRoundtrip_splits2 term =
-    and [          deserialise thedata'
+    and [          Term.deserialise thedata'
           `eqTerm` (canonicaliseTermNaNs . canonicaliseTermIntegers) term
-        | let thedata = serialise term
+        | let thedata = Term.serialise term
         , thedata' <- splits2 thedata ]
 
 prop_encodeDecodeTermRoundtrip_splits3 :: Term -> Bool
 prop_encodeDecodeTermRoundtrip_splits3 term =
-    and [          deserialise thedata'
+    and [          Term.deserialise thedata'
           `eqTerm` (canonicaliseTermNaNs . canonicaliseTermIntegers) term
-        | let thedata = serialise term
+        | let thedata = Term.serialise term
         , thedata' <- splits3 thedata ]
 
-prop_encodeTermMatchesRefImpl :: RefImpl.Term -> Bool
+prop_encodeTermMatchesRefImpl :: Ref.Term -> Bool
 prop_encodeTermMatchesRefImpl term =
-    let encoded  = serialise (fromRefTerm term)
-        encoded' = RefImpl.serialise (RefImpl.canonicaliseTerm term)
+    let encoded  = Term.serialise (fromRefTerm term)
+        encoded' = Ref.serialise (Ref.canonicaliseTerm term)
      in encoded == encoded'
 
 prop_encodeTermMatchesRefImpl2 :: Term -> Bool
 prop_encodeTermMatchesRefImpl2 term =
-    let encoded  = serialise term
-        encoded' = RefImpl.serialise (toRefTerm term)
+    let encoded  = Term.serialise term
+        encoded' = Ref.serialise (toRefTerm term)
      in encoded == encoded'
 
-prop_decodeTermMatchesRefImpl :: RefImpl.Term -> Bool
+prop_decodeTermMatchesRefImpl :: Ref.Term -> Bool
 prop_decodeTermMatchesRefImpl term0 =
-    let encoded = RefImpl.serialise term0
-        term    = RefImpl.deserialise encoded
-        term'   = deserialise encoded
+    let encoded = Ref.serialise term0
+        term    = Ref.deserialise encoded
+        term'   = Term.deserialise encoded
      in term' `eqTerm` fromRefTerm term
 
-prop_decodeTermNonCanonical :: RefImpl.Term -> Property
+prop_decodeTermNonCanonical :: Ref.Term -> Property
 prop_decodeTermNonCanonical term0 =
-    let encoded = RefImpl.serialise term0
-        term    = RefImpl.deserialise encoded
-        term'   = deserialise encoded
-        encoded'= serialise term'
+    let encoded = Ref.serialise term0
+        term    = Ref.deserialise encoded
+        term'   = Term.deserialise encoded
+        encoded'= Term.serialise term'
         isCanonical = encoded == encoded'
      in not isCanonical ==>
         -- This property holds without this pre-condition, as demonstrated by

--- a/cborg/tests/Tests/Properties.hs
+++ b/cborg/tests/Tests/Properties.hs
@@ -9,6 +9,33 @@
 
 module Tests.Properties (
     testTree
+
+    -- * Token type class and derived functions
+  , Token(..)
+  , serialiseRef
+  , serialiseImp
+  , deserialiseRef
+  , deserialiseImp
+
+    -- * Various test token types
+  , TokInt
+  , TokInt8
+  , TokInt16
+  , TokInt32
+  , TokInt64
+  , TokInteger
+  , TokWord
+  , TokWord8
+  , TokWord16
+  , TokWord32
+  , TokWord64
+  , TokHalf
+  , TokFloat
+  , TokDouble
+  , TokTag
+  , TokTag64
+  , Ref.Simple
+  , Ref.Term
   ) where
 
 import           Prelude hiding (decodeFloat, encodeFloat)

--- a/cborg/tests/Tests/Properties.hs
+++ b/cborg/tests/Tests/Properties.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Tests.Properties (
+    testTree
+  ) where
+
+import           Codec.CBOR.Term
+
+import           Test.Tasty (TestTree, testGroup, localOption)
+import           Test.Tasty.QuickCheck (testProperty, QuickCheckMaxSize(..))
+import           Test.QuickCheck
+
+import qualified Tests.Reference.Implementation as RefImpl
+import           Tests.Term
+                   ( fromRefTerm, toRefTerm, eqTerm
+                   , prop_toFromRefTerm, prop_fromToRefTerm
+                   , serialise, deserialise
+                   , canonicaliseTermNaNs, canonicaliseTermIntegers )
+import           Tests.Util
+
+#if !MIN_VERSION_base(4,8,0)
+import           Control.Applicative
+#endif
+
+
+--------------------------------------------------------------------------------
+-- Properties
+--
+
+prop_encodeDecodeTermRoundtrip :: Term -> Bool
+prop_encodeDecodeTermRoundtrip term =
+             (deserialise . serialise) term
+    `eqTerm` (canonicaliseTermNaNs . canonicaliseTermIntegers) term
+
+prop_encodeDecodeTermRoundtrip_splits2 :: Term -> Bool
+prop_encodeDecodeTermRoundtrip_splits2 term =
+    and [          deserialise thedata'
+          `eqTerm` (canonicaliseTermNaNs . canonicaliseTermIntegers) term
+        | let thedata = serialise term
+        , thedata' <- splits2 thedata ]
+
+prop_encodeDecodeTermRoundtrip_splits3 :: Term -> Bool
+prop_encodeDecodeTermRoundtrip_splits3 term =
+    and [          deserialise thedata'
+          `eqTerm` (canonicaliseTermNaNs . canonicaliseTermIntegers) term
+        | let thedata = serialise term
+        , thedata' <- splits3 thedata ]
+
+prop_encodeTermMatchesRefImpl :: RefImpl.Term -> Bool
+prop_encodeTermMatchesRefImpl term =
+    let encoded  = serialise (fromRefTerm term)
+        encoded' = RefImpl.serialise (RefImpl.canonicaliseTerm term)
+     in encoded == encoded'
+
+prop_encodeTermMatchesRefImpl2 :: Term -> Bool
+prop_encodeTermMatchesRefImpl2 term =
+    let encoded  = serialise term
+        encoded' = RefImpl.serialise (toRefTerm term)
+     in encoded == encoded'
+
+prop_decodeTermMatchesRefImpl :: RefImpl.Term -> Bool
+prop_decodeTermMatchesRefImpl term0 =
+    let encoded = RefImpl.serialise term0
+        term    = RefImpl.deserialise encoded
+        term'   = deserialise encoded
+     in term' `eqTerm` fromRefTerm term
+
+prop_decodeTermNonCanonical :: RefImpl.Term -> Property
+prop_decodeTermNonCanonical term0 =
+    let encoded = RefImpl.serialise term0
+        term    = RefImpl.deserialise encoded
+        term'   = deserialise encoded
+        encoded'= serialise term'
+        isCanonical = encoded == encoded'
+     in not isCanonical ==>
+        -- This property holds without this pre-condition, as demonstrated by
+        -- prop_decodeTermMatchesRefImpl, but using it ensures we get good
+        -- coverage of the non-canonical cases
+        term' `eqTerm` fromRefTerm term
+
+
+--------------------------------------------------------------------------------
+-- TestTree API
+
+testTree :: TestTree
+testTree =
+  testGroup "properties"
+    [ testProperty "from/to reference terms"        prop_fromToRefTerm
+    , testProperty "to/from reference terms"        prop_toFromRefTerm
+    , testProperty "rountrip de/encoding terms"     prop_encodeDecodeTermRoundtrip
+      -- TODO FIXME: need to fix the generation of terms to give
+      -- better size distribution some get far too big for the
+      -- splits properties.
+    , localOption (QuickCheckMaxSize 30) $
+      testProperty "decoding with all 2-chunks"     prop_encodeDecodeTermRoundtrip_splits2
+    , localOption (QuickCheckMaxSize 20) $
+      testProperty "decoding with all 3-chunks"     prop_encodeDecodeTermRoundtrip_splits3
+    , testProperty "encode term matches ref impl 1" prop_encodeTermMatchesRefImpl
+    , testProperty "encode term matches ref impl 2" prop_encodeTermMatchesRefImpl2
+    , testProperty "decoding term matches ref impl" prop_decodeTermMatchesRefImpl
+    , testProperty "non-canonical encoding"         prop_decodeTermNonCanonical
+    ]

--- a/cborg/tests/Tests/Properties.hs
+++ b/cborg/tests/Tests/Properties.hs
@@ -17,7 +17,7 @@ import qualified Tests.Term as Term (serialise, deserialise)
 import           Tests.Term
                    ( fromRefTerm, toRefTerm, eqTerm
                    , prop_toFromRefTerm, prop_fromToRefTerm
-                   , canonicaliseTermNaNs, canonicaliseTermIntegers )
+                   , canonicaliseTerm )
 import           Tests.Util
 
 #if !MIN_VERSION_base(4,8,0)
@@ -32,19 +32,19 @@ import           Control.Applicative
 prop_encodeDecodeTermRoundtrip :: Term -> Bool
 prop_encodeDecodeTermRoundtrip term =
              (Term.deserialise . Term.serialise) term
-    `eqTerm` (canonicaliseTermNaNs . canonicaliseTermIntegers) term
+    `eqTerm` canonicaliseTerm term
 
 prop_encodeDecodeTermRoundtrip_splits2 :: Term -> Bool
 prop_encodeDecodeTermRoundtrip_splits2 term =
     and [          Term.deserialise thedata'
-          `eqTerm` (canonicaliseTermNaNs . canonicaliseTermIntegers) term
+          `eqTerm` canonicaliseTerm term
         | let thedata = Term.serialise term
         , thedata' <- splits2 thedata ]
 
 prop_encodeDecodeTermRoundtrip_splits3 :: Term -> Bool
 prop_encodeDecodeTermRoundtrip_splits3 term =
     and [          Term.deserialise thedata'
-          `eqTerm` (canonicaliseTermNaNs . canonicaliseTermIntegers) term
+          `eqTerm` canonicaliseTerm term
         | let thedata = Term.serialise term
         , thedata' <- splits3 thedata ]
 

--- a/cborg/tests/Tests/Properties.hs
+++ b/cborg/tests/Tests/Properties.hs
@@ -11,7 +11,14 @@ module Tests.Properties (
     testTree
   ) where
 
+import           Prelude hiding (decodeFloat, encodeFloat)
+
 import qualified Data.ByteString.Lazy as LBS
+import           Data.Word
+import           Data.Int
+import           Data.Bits (complement)
+import qualified Numeric.Half as Half
+import           Data.Function (on)
 
 import           Codec.CBOR.Term
 import           Codec.CBOR.Read
@@ -22,8 +29,11 @@ import           Codec.CBOR.Encoding
 import           Test.Tasty (TestTree, testGroup, localOption)
 import           Test.Tasty.QuickCheck (testProperty, QuickCheckMaxSize(..))
 import           Test.QuickCheck
+import           System.Random (Random)
 
 import qualified Tests.Reference.Implementation as Ref
+import           Tests.Reference.Implementation (UInt(..))
+import           Tests.Reference.Generators
 import           Tests.Term
                    ( fromRefTerm, toRefTerm, eqTerm, canonicaliseTerm )
 import           Tests.Util
@@ -320,6 +330,575 @@ prop_decodeRefdecodeImp x =
 
 
 --------------------------------------------------------------------------------
+-- Token class instances for unsigned types
+--
+
+newtype TokWord8 = TokWord8 { unTokWord8 :: UInt }
+  deriving (Eq, Show)
+
+instance Token TokWord8 where
+    type Imp TokWord8 = Word8
+
+    fromRef = fromIntegral . Ref.fromUInt . unTokWord8
+    toRef   = TokWord8 . Ref.toUInt . fromIntegral
+
+    encodeImp = encodeWord8
+    decodeImp = decodeWord8
+
+    encodeRef (TokWord8 n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
+    decodeRef = do Ref.MT0_UnsignedInt n <- Ref.decodeToken
+                   return (TokWord8 n)
+
+instance Arbitrary TokWord8 where
+    arbitrary = TokWord8 <$> oneof arbitraryUInt_Word8
+
+arbitraryUInt_Word8 :: [Gen UInt]
+arbitraryUInt_Word8  = [ UIntSmall <$> arbitrarySmall
+                       , UInt8     <$> arbitrarySmall
+                       , UInt8     <$> arbitraryUInt8
+                       ]
+
+
+newtype TokWord16 = TokWord16 { unTokWord16 :: UInt }
+  deriving (Eq, Show)
+
+instance Token TokWord16 where
+    type Imp TokWord16 = Word16
+
+    fromRef = fromIntegral . Ref.fromUInt . unTokWord16
+    toRef   = TokWord16 . Ref.toUInt . fromIntegral
+
+    encodeImp = encodeWord16
+    decodeImp = decodeWord16
+
+    encodeRef (TokWord16 n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
+    decodeRef = do Ref.MT0_UnsignedInt n <- Ref.decodeToken
+                   return (TokWord16 n)
+
+instance Arbitrary TokWord16 where
+      arbitrary = TokWord16 <$> oneof arbitraryUInt_Word16
+
+arbitraryUInt_Word16 :: [Gen UInt]
+arbitraryUInt_Word16 = arbitraryUInt_Word8
+                    ++ [ UInt16 <$> arbitrarySmall
+                       , UInt16 <$> arbitraryUInt8
+                       , UInt16 <$> arbitraryUInt16
+                       ]
+
+
+newtype TokWord32 = TokWord32 { unTokWord32 :: UInt }
+  deriving (Eq, Show)
+
+instance Token TokWord32 where
+    type Imp TokWord32 = Word32
+
+    fromRef = fromIntegral . Ref.fromUInt . unTokWord32
+    toRef   = TokWord32 . Ref.toUInt . fromIntegral
+
+    encodeImp = encodeWord32
+    decodeImp = decodeWord32
+
+    encodeRef (TokWord32 n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
+    decodeRef = do Ref.MT0_UnsignedInt n <- Ref.decodeToken
+                   return (TokWord32 n)
+
+instance Arbitrary TokWord32 where
+    arbitrary = TokWord32 <$> oneof arbitraryUInt_Word32
+
+arbitraryUInt_Word32 :: [Gen UInt]
+arbitraryUInt_Word32 = arbitraryUInt_Word16
+                    ++ [ UInt32 <$> arbitrarySmall
+                       , UInt32 <$> arbitraryUInt8
+                       , UInt32 <$> arbitraryUInt16
+                       , UInt32 <$> arbitraryUInt32
+                       ]
+
+newtype TokWord64 = TokWord64 { unTokWord64 :: UInt }
+  deriving (Eq, Show)
+
+instance Token TokWord64 where
+    type Imp TokWord64 = Word64
+
+    fromRef = fromIntegral . Ref.fromUInt . unTokWord64
+    toRef   = TokWord64 . Ref.toUInt . fromIntegral
+
+    encodeImp = encodeWord64
+    decodeImp = decodeWord64
+
+    encodeRef (TokWord64 n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
+    decodeRef = do Ref.MT0_UnsignedInt n <- Ref.decodeToken
+                   return (TokWord64 n)
+
+instance Arbitrary TokWord64 where
+    arbitrary = TokWord64 <$> oneof arbitraryUInt_Word64
+
+arbitraryUInt_Word64 :: [Gen UInt]
+arbitraryUInt_Word64 = arbitraryUInt_Word32
+                    ++ [ UInt64 <$> arbitrarySmall
+                       , UInt64 <$> arbitraryUInt8
+                       , UInt64 <$> arbitraryUInt16
+                       , UInt64 <$> arbitraryUInt32
+                       , UInt64 <$> arbitraryUInt64
+                       ]
+
+
+newtype TokWord = TokWord { unTokWord :: UInt }
+  deriving (Eq, Show)
+
+instance Arbitrary TokWord where
+    arbitrary = TokWord <$> oneof arbitraryUInt_Word
+
+arbitraryUInt_Word :: [Gen UInt]
+arbitraryUInt_Word   = arbitraryUInt_Word32
+                    ++ [ UInt64 <$> arbitrarySmall
+                       , UInt64 <$> arbitraryUInt8
+                       , UInt64 <$> arbitraryUInt16
+                       , UInt64 <$> arbitraryUInt32
+#if defined(ARCH_64bit)
+                       , UInt64 <$> arbitraryUInt64
+#endif
+                       ]
+
+instance Token TokWord where
+    type Imp TokWord = Word
+
+    fromRef = fromIntegral . Ref.fromUInt . unTokWord
+    toRef   = TokWord . Ref.toUInt . fromIntegral
+
+    encodeImp = encodeWord
+    decodeImp = decodeWord
+
+    encodeRef (TokWord n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
+    decodeRef = do Ref.MT0_UnsignedInt n <- Ref.decodeToken
+                   return (TokWord n)
+
+
+--------------------------------------------------------------------------------
+-- Token class instances for signed types
+--
+
+
+data TokInt8 = TokInt8 Bool UInt
+  deriving (Eq, Show)
+
+instance Token TokInt8 where
+    type Imp TokInt8 = Int8
+
+    fromRef (TokInt8 True  n) =              (fromIntegral . Ref.fromUInt) n
+    fromRef (TokInt8 False n) = (complement . fromIntegral . Ref.fromUInt) n
+    toRef n | n >= 0    = TokInt8 True  ((Ref.toUInt . fromIntegral) n)
+            | otherwise = TokInt8 False ((Ref.toUInt . fromIntegral . complement) n)
+
+    encodeImp = encodeInt8
+    decodeImp = decodeInt8
+
+    encodeRef (TokInt8 True  n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
+    encodeRef (TokInt8 False n) = Ref.encodeToken (Ref.MT1_NegativeInt n)
+
+    decodeRef = do tok <- Ref.decodeToken
+                   case tok of
+                     Ref.MT0_UnsignedInt n -> return (TokInt8 True  n)
+                     Ref.MT1_NegativeInt n -> return (TokInt8 False n)
+                     _                     -> fail "decodeRef (TokInt)"
+
+instance Arbitrary TokInt8 where
+    arbitrary = TokInt8 <$> arbitrary <*> oneof arbitraryUInt_Int8
+    shrink (TokInt8 sign n) = [ TokInt8 sign' n'
+                              | (sign', n') <- shrink (sign, n) ]
+
+arbitraryUInt_Int8 :: [Gen UInt]
+arbitraryUInt_Int8   = [ UIntSmall <$> arbitrarySmall
+                       , UInt8     <$> arbitrarySmall
+                       , UInt8     <$> arbitraryUInt7
+                       ]
+
+
+data TokInt16 = TokInt16 Bool UInt
+  deriving (Eq, Show)
+
+instance Token TokInt16 where
+    type Imp TokInt16 = Int16
+
+    fromRef (TokInt16 True  n) =              (fromIntegral . Ref.fromUInt) n
+    fromRef (TokInt16 False n) = (complement . fromIntegral . Ref.fromUInt) n
+    toRef n | n >= 0    = TokInt16 True  ((Ref.toUInt . fromIntegral) n)
+            | otherwise = TokInt16 False ((Ref.toUInt . fromIntegral . complement) n)
+
+    encodeImp = encodeInt16
+    decodeImp = decodeInt16
+
+    encodeRef (TokInt16 True  n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
+    encodeRef (TokInt16 False n) = Ref.encodeToken (Ref.MT1_NegativeInt n)
+
+    decodeRef = do tok <- Ref.decodeToken
+                   case tok of
+                     Ref.MT0_UnsignedInt n -> return (TokInt16 True  n)
+                     Ref.MT1_NegativeInt n -> return (TokInt16 False n)
+                     _                     -> fail "decodeRef (TokInt16)"
+
+
+instance Arbitrary TokInt16 where
+    arbitrary = TokInt16 <$> arbitrary <*> oneof arbitraryUInt_Int16
+
+arbitraryUInt_Int16 :: [Gen UInt]
+arbitraryUInt_Int16  = arbitraryUInt_Int8
+                    ++ [ UInt16 <$> arbitrarySmall
+                       , UInt16 <$> arbitraryUInt7
+                       , UInt16 <$> arbitraryUInt15
+                       ]
+
+
+data TokInt32 = TokInt32 Bool UInt
+  deriving (Eq, Show)
+
+instance Token TokInt32 where
+    type Imp TokInt32 = Int32
+
+    fromRef (TokInt32 True  n) =              (fromIntegral . Ref.fromUInt) n
+    fromRef (TokInt32 False n) = (complement . fromIntegral . Ref.fromUInt) n
+    toRef n | n >= 0    = TokInt32 True  ((Ref.toUInt . fromIntegral) n)
+            | otherwise = TokInt32 False ((Ref.toUInt . fromIntegral . complement) n)
+
+    encodeImp = encodeInt32
+    decodeImp = decodeInt32
+
+    encodeRef (TokInt32 True  n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
+    encodeRef (TokInt32 False n) = Ref.encodeToken (Ref.MT1_NegativeInt n)
+
+    decodeRef = do tok <- Ref.decodeToken
+                   case tok of
+                     Ref.MT0_UnsignedInt n -> return (TokInt32 True  n)
+                     Ref.MT1_NegativeInt n -> return (TokInt32 False n)
+                     _                     -> fail "decodeRef (TokInt32)"
+
+instance Arbitrary TokInt32 where
+    arbitrary = TokInt32 <$> arbitrary <*> oneof arbitraryUInt_Int32
+
+arbitraryUInt_Int32 :: [Gen UInt]
+arbitraryUInt_Int32  = arbitraryUInt_Int16
+                    ++ [ UInt32 <$> arbitrarySmall
+                       , UInt32 <$> arbitraryUInt7
+                       , UInt32 <$> arbitraryUInt15
+                       , UInt32 <$> arbitraryUInt31
+                       ]
+
+
+data TokInt64 = TokInt64 Bool UInt
+  deriving (Eq, Show)
+
+instance Token TokInt64 where
+    type Imp TokInt64 = Int64
+
+    fromRef (TokInt64 True  n) =              (fromIntegral . Ref.fromUInt) n
+    fromRef (TokInt64 False n) = (complement . fromIntegral . Ref.fromUInt) n
+    toRef n | n >= 0    = TokInt64 True  ((Ref.toUInt . fromIntegral) n)
+            | otherwise = TokInt64 False ((Ref.toUInt . fromIntegral . complement) n)
+
+    encodeImp = encodeInt64
+    decodeImp = decodeInt64
+
+    encodeRef (TokInt64 True  n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
+    encodeRef (TokInt64 False n) = Ref.encodeToken (Ref.MT1_NegativeInt n)
+
+    decodeRef = do tok <- Ref.decodeToken
+                   case tok of
+                     Ref.MT0_UnsignedInt n -> return (TokInt64 True  n)
+                     Ref.MT1_NegativeInt n -> return (TokInt64 False n)
+                     _                     -> fail "decodeRef (TokInt64)"
+
+instance Arbitrary TokInt64 where
+    arbitrary = TokInt64 <$> arbitrary <*> oneof arbitraryUInt_Int64
+
+arbitraryUInt_Int64 :: [Gen UInt]
+arbitraryUInt_Int64  = arbitraryUInt_Int32
+                    ++ [ UInt64 <$> arbitrarySmall
+                       , UInt64 <$> arbitraryUInt7
+                       , UInt64 <$> arbitraryUInt15
+                       , UInt64 <$> arbitraryUInt31
+                       , UInt64 <$> arbitraryUInt63
+                       ]
+
+
+data TokInt = TokInt Bool UInt
+  deriving (Eq, Show)
+
+instance Token TokInt where
+    type Imp TokInt = Int
+
+    fromRef (TokInt True  n) =              (fromIntegral . Ref.fromUInt) n
+    fromRef (TokInt False n) = (complement . fromIntegral . Ref.fromUInt) n
+    toRef n | n >= 0    = TokInt True  ((Ref.toUInt . fromIntegral) n)
+            | otherwise = TokInt False ((Ref.toUInt . fromIntegral . complement) n)
+
+    encodeImp = encodeInt
+    decodeImp = decodeInt
+
+    encodeRef (TokInt True  n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
+    encodeRef (TokInt False n) = Ref.encodeToken (Ref.MT1_NegativeInt n)
+
+    decodeRef = do tok <- Ref.decodeToken
+                   case tok of
+                     Ref.MT0_UnsignedInt n -> return (TokInt True  n)
+                     Ref.MT1_NegativeInt n -> return (TokInt False n)
+                     _                     -> fail "decodeRef (TokInt)"
+
+instance Arbitrary TokInt where
+    arbitrary = TokInt <$> arbitrary <*> oneof arbitraryUInt_Int
+
+arbitraryUInt_Int :: [Gen UInt]
+arbitraryUInt_Int    = arbitraryUInt_Int32
+                    ++ [ UInt64 <$> arbitrarySmall
+                       , UInt64 <$> arbitraryUInt7
+                       , UInt64 <$> arbitraryUInt15
+                       , UInt64 <$> arbitraryUInt31
+#if defined(ARCH_64bit)
+                       , UInt64 <$> arbitraryUInt63
+#endif
+                       ]
+
+
+data TokInteger = TokIntegerUInt UInt
+                | TokIntegerNInt UInt
+                | TokIntegerBig  LargeInteger
+  deriving (Eq, Show)
+
+instance Arbitrary TokInteger where
+  arbitrary = oneof [ TokIntegerUInt <$> arbitrary
+                    , TokIntegerNInt <$> arbitrary
+                    , TokIntegerBig  <$> arbitrary
+                    ]
+
+
+instance Token TokInteger where
+    type Imp TokInteger = Integer
+
+    fromRef (TokIntegerUInt n) =              (fromIntegral . Ref.fromUInt) n
+    fromRef (TokIntegerNInt n) = (complement . fromIntegral . Ref.fromUInt) n
+    fromRef (TokIntegerBig  n) = getLargeInteger n
+
+    toRef n | n >= 0 && n <= fromIntegral (maxBound :: Word64)
+            = TokIntegerUInt ((Ref.toUInt . fromIntegral) n)
+
+            | n < 0  && complement n <= fromIntegral (maxBound :: Word64)
+            = TokIntegerNInt ((Ref.toUInt . fromIntegral . complement) n)
+
+            | otherwise = TokIntegerBig (LargeInteger n)
+
+    encodeImp = encodeInteger
+    decodeImp = decodeInteger
+
+    encodeRef (TokIntegerUInt n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
+    encodeRef (TokIntegerNInt n) = Ref.encodeToken (Ref.MT1_NegativeInt n)
+    encodeRef (TokIntegerBig  n) = Ref.encodeTerm (Ref.TBigInt (getLargeInteger n))
+
+    decodeRef = do
+      tok <- Ref.decodeToken
+      case tok of
+        Ref.MT0_UnsignedInt n -> return (TokIntegerUInt  n)
+        Ref.MT1_NegativeInt n -> return (TokIntegerNInt n)
+        Ref.MT6_Tag       tag -> do Ref.TBigInt n <- Ref.decodeTagged tag
+                                    return (TokIntegerBig (LargeInteger n))
+        _                     -> fail "decodeRef (TokInteger)"
+
+
+--------------------------------------------------------------------------------
+-- Arbitrary helpers for integer types
+--
+
+arbitrarySmall,
+  arbitraryUInt8, arbitraryUInt16, arbitraryUInt32, arbitraryUInt64,
+  arbitraryUInt7, arbitraryUInt15, arbitraryUInt31, arbitraryUInt63
+  :: (Num n, Random n) => Gen n
+
+arbitrarySmall  = chooseZeroToBound (23       :: Word)
+arbitraryUInt8  = chooseZeroToBound (maxBound :: Word8)
+arbitraryUInt16 = chooseZeroToBound (maxBound :: Word16)
+arbitraryUInt32 = chooseZeroToBound (maxBound :: Word32)
+arbitraryUInt64 = chooseZeroToBound (maxBound :: Word64)
+
+arbitraryUInt7  = chooseZeroToBound (maxBound :: Int8)
+arbitraryUInt15 = chooseZeroToBound (maxBound :: Int16)
+arbitraryUInt31 = chooseZeroToBound (maxBound :: Int32)
+arbitraryUInt63 = chooseZeroToBound (maxBound :: Int64)
+
+chooseZeroToBound :: (Num a, Random a, Integral a1) => a1 -> Gen a
+chooseZeroToBound bound =
+    frequency [ (9, choose (0, bound'))
+              , (1, pure bound') ]
+  where
+    bound' = fromIntegral bound
+
+
+--------------------------------------------------------------------------------
+-- Token class instances for floating point types
+--
+
+data TokHalf = TokHalf HalfSpecials
+  deriving (Eq, Show)
+
+instance Arbitrary TokHalf where
+  arbitrary = TokHalf <$> arbitrary
+
+instance Token TokHalf where
+    type Imp TokHalf = Float
+
+    eqImp = (==) `on` floatToWord
+
+    fromRef (TokHalf (HalfSpecials n)) = Half.fromHalf n
+    toRef = TokHalf
+          . canonicaliseNaN
+          . HalfSpecials
+          . Half.toHalf
+
+    canonicaliseImp = Half.fromHalf
+                    . canonicaliseNaN
+                    . Half.toHalf
+    canonicaliseRef (TokHalf n) = TokHalf (canonicaliseNaN n)
+
+    encodeImp = encodeFloat16
+    decodeImp = decodeFloat
+
+    encodeRef (TokHalf n) = Ref.encodeToken (Ref.MT7_Float16 n)
+    decodeRef = do Ref.MT7_Float16 n <- Ref.decodeToken
+                   return (TokHalf n)
+
+data TokFloat = TokFloat FloatSpecials
+              | TokFloatNan
+  deriving (Eq, Show)
+
+instance Arbitrary TokFloat where
+  arbitrary = frequency [(19, TokFloat <$> arbitrary), (1, pure TokFloatNan)]
+
+instance Token TokFloat where
+    type Imp TokFloat = Float
+
+    eqImp = (==) `on` floatToWord
+
+    fromRef (TokFloat n) = getFloatSpecials n
+    fromRef TokFloatNan  = canonicalNaN
+    toRef n
+      | isNaN n   = TokFloatNan
+      | otherwise = TokFloat (FloatSpecials n)
+
+    canonicaliseImp = canonicaliseNaN
+
+    canonicaliseRef TokFloatNan = TokFloatNan
+    canonicaliseRef (TokFloat (FloatSpecials n))
+      | isNaN n   = TokFloatNan
+      | otherwise = TokFloat (FloatSpecials n)
+
+    encodeImp = encodeFloat
+    decodeImp = decodeFloat
+
+    encodeRef (TokFloat n) = Ref.encodeToken (Ref.MT7_Float32 n)
+    encodeRef TokFloatNan  = Ref.encodeToken (Ref.MT7_Float16 canonicalNaN)
+
+    decodeRef = do tok <- Ref.decodeToken
+                   case tok of
+                     Ref.MT7_Float16 n | isNaN n
+                                       -> return TokFloatNan
+                     Ref.MT7_Float32 n -> return (TokFloat n)
+                     _                 -> fail "decodeRef (TokFloat)"
+
+
+data TokDouble = TokDouble DoubleSpecials
+               | TokDoubleNan
+  deriving (Eq, Show)
+
+instance Arbitrary TokDouble where
+  arbitrary = frequency [(19, TokDouble <$> arbitrary), (1, pure TokDoubleNan)]
+
+instance Token TokDouble where
+    type Imp TokDouble = Double
+
+    eqImp = (==) `on` doubleToWord
+
+    fromRef (TokDouble n) = getDoubleSpecials n
+    fromRef TokDoubleNan  = canonicalNaN
+    toRef n
+      | isNaN n   = TokDoubleNan
+      | otherwise = TokDouble (DoubleSpecials n)
+
+    canonicaliseImp = canonicaliseNaN
+    canonicaliseRef TokDoubleNan = TokDoubleNan
+    canonicaliseRef (TokDouble (DoubleSpecials n))
+      | isNaN n   = TokDoubleNan
+      | otherwise = TokDouble (DoubleSpecials n)
+
+    encodeImp = encodeDouble
+    decodeImp = decodeDouble
+
+    encodeRef (TokDouble n) = Ref.encodeToken (Ref.MT7_Float64 n)
+    encodeRef TokDoubleNan  = Ref.encodeToken (Ref.MT7_Float16 canonicalNaN)
+
+    decodeRef = do tok <- Ref.decodeToken
+                   case tok of
+                     Ref.MT7_Float16 n | isNaN n
+                                       -> return TokDoubleNan
+                     Ref.MT7_Float64 n -> return (TokDouble n)
+                     _                 -> fail "decodeRef (TokDouble)"
+
+
+--------------------------------------------------------------------------------
+-- Miscelaneous token class instances
+--
+
+data TokTag = TokTag { unTokTag :: UInt }
+  deriving (Eq, Show)
+
+instance Arbitrary TokTag where
+    arbitrary = TokTag <$> oneof arbitraryUInt_Word
+
+instance Token TokTag where
+    type Imp TokTag = Word
+
+    fromRef = fromIntegral . Ref.fromUInt . unTokTag
+    toRef   = TokTag . Ref.toUInt . fromIntegral
+
+    encodeImp = encodeTag
+    decodeImp = decodeTag
+
+    encodeRef (TokTag n) = Ref.encodeToken (Ref.MT6_Tag n)
+    decodeRef            = do Ref.MT6_Tag n <- Ref.decodeToken
+                              return (TokTag n)
+
+
+data TokTag64 = TokTag64 { unTokTag64 :: UInt }
+  deriving (Eq, Show)
+
+instance Arbitrary TokTag64 where
+    arbitrary = TokTag64 <$> oneof arbitraryUInt_Word64
+
+instance Token TokTag64 where
+    type Imp TokTag64 = Word64
+
+    fromRef = fromIntegral . Ref.fromUInt . unTokTag64
+    toRef   = TokTag64 . Ref.toUInt . fromIntegral
+
+    encodeImp = encodeTag64
+    decodeImp = decodeTag64
+
+    encodeRef (TokTag64 n) = Ref.encodeToken (Ref.MT6_Tag n)
+    decodeRef              = do Ref.MT6_Tag n <- Ref.decodeToken
+                                return (TokTag64 n)
+
+
+
+instance Token Ref.Simple where
+    type Imp Ref.Simple = Word8
+
+    fromRef = Ref.fromSimple
+    toRef   = Ref.toSimple
+
+    encodeImp = encodeSimple
+    decodeImp = decodeSimple
+
+    encodeRef n = Ref.encodeToken (Ref.MT7_Simple n)
+    decodeRef   = do Ref.MT7_Simple n <- Ref.decodeToken
+                     return n
+
+
+--------------------------------------------------------------------------------
 -- Token class instances for Term type
 --
 
@@ -348,40 +927,202 @@ testTree :: TestTree
 testTree =
   testGroup "properties"
   [ testGroup "to . id . from = canon_ref"
-    [ testProperty "Term"    (prop_fromRefToRef @ Ref.Term)
+    [ testProperty "Word8"   (prop_fromRefToRef @ TokWord8)
+    , testProperty "Word16"  (prop_fromRefToRef @ TokWord16)
+    , testProperty "Word32"  (prop_fromRefToRef @ TokWord32)
+    , testProperty "Word64"  (prop_fromRefToRef @ TokWord64)
+    , testProperty "Word"    (prop_fromRefToRef @ TokWord)
+--  , testProperty "NegWord" (prop_fromRefToRef @ TokNegWord)
+    , testProperty "Int8"    (prop_fromRefToRef @ TokInt8)
+    , testProperty "Int16"   (prop_fromRefToRef @ TokInt16)
+    , testProperty "Int32"   (prop_fromRefToRef @ TokInt32)
+    , testProperty "Int64"   (prop_fromRefToRef @ TokInt64)
+    , testProperty "Int"     (prop_fromRefToRef @ TokInt)
+    , testProperty "Integer" (prop_fromRefToRef @ TokInteger)
+    , testProperty "Half"    (prop_fromRefToRef @ TokHalf)
+    , testProperty "Float"   (prop_fromRefToRef @ TokFloat)
+    , testProperty "Double"  (prop_fromRefToRef @ TokDouble)
+    , testProperty "Tag"     (prop_fromRefToRef @ TokTag)
+    , testProperty "Tag64"   (prop_fromRefToRef @ TokTag64)
+    , testProperty "Simple"  (prop_fromRefToRef @ Ref.Simple)
+    , testProperty "Term"    (prop_fromRefToRef @ Ref.Term)
     ]
 
   , testGroup "from . id . to = canon_imp"
-    [ testProperty "Term"    (prop_toRefFromRef @ Ref.Term)
+    [ testProperty "Word8"   (prop_toRefFromRef @ TokWord8)
+    , testProperty "Word16"  (prop_toRefFromRef @ TokWord16)
+    , testProperty "Word32"  (prop_toRefFromRef @ TokWord32)
+    , testProperty "Word64"  (prop_toRefFromRef @ TokWord64)
+    , testProperty "Word"    (prop_toRefFromRef @ TokWord)
+--  , testProperty "NegWord" (prop_toRefFromRef @ TokNegWord)
+    , testProperty "Int8"    (prop_toRefFromRef @ TokInt8)
+    , testProperty "Int16"   (prop_toRefFromRef @ TokInt16)
+    , testProperty "Int32"   (prop_toRefFromRef @ TokInt32)
+    , testProperty "Int64"   (prop_toRefFromRef @ TokInt64)
+    , testProperty "Int"     (prop_toRefFromRef @ TokInt)
+    , testProperty "Integer" (prop_toRefFromRef @ TokInteger)
+    , testProperty "Half"    (prop_toRefFromRef @ TokHalf)
+    , testProperty "Float"   (prop_toRefFromRef @ TokFloat)
+    , testProperty "Double"  (prop_toRefFromRef @ TokDouble)
+    , testProperty "Tag"     (prop_toRefFromRef @ TokTag)
+    , testProperty "Tag64"   (prop_toRefFromRef @ TokTag64)
+    , testProperty "Simple"  (prop_toRefFromRef @ Ref.Simple)
+    , testProperty "Term"    (prop_toRefFromRef @ Ref.Term)
     ]
 
   , testGroup "dec_ref . enc_ref = id"
-    [ testProperty "Term"    (prop_encodeRefdecodeRef @ Ref.Term)
+    [ testProperty "Word8"   (prop_encodeRefdecodeRef @ TokWord8)
+    , testProperty "Word16"  (prop_encodeRefdecodeRef @ TokWord16)
+    , testProperty "Word32"  (prop_encodeRefdecodeRef @ TokWord32)
+    , testProperty "Word64"  (prop_encodeRefdecodeRef @ TokWord64)
+    , testProperty "Word"    (prop_encodeRefdecodeRef @ TokWord)
+--  , testProperty "NegWord" (prop_encodeRefdecodeRef @ TokNegWord)
+    , testProperty "Int8"    (prop_encodeRefdecodeRef @ TokInt8)
+    , testProperty "Int16"   (prop_encodeRefdecodeRef @ TokInt16)
+    , testProperty "Int32"   (prop_encodeRefdecodeRef @ TokInt32)
+    , testProperty "Int64"   (prop_encodeRefdecodeRef @ TokInt64)
+    , testProperty "Int"     (prop_encodeRefdecodeRef @ TokInt)
+    , testProperty "Integer" (prop_encodeRefdecodeRef @ TokInteger)
+    , testProperty "Half"    (prop_encodeRefdecodeRef @ TokHalf)
+    , testProperty "Float"   (prop_encodeRefdecodeRef @ TokFloat)
+    , testProperty "Double"  (prop_encodeRefdecodeRef @ TokDouble)
+    , testProperty "Tag"     (prop_encodeRefdecodeRef @ TokTag)
+    , testProperty "Tag64"   (prop_encodeRefdecodeRef @ TokTag64)
+    , testProperty "Simple"  (prop_encodeRefdecodeRef @ Ref.Simple)
+    , testProperty "Term"    (prop_encodeRefdecodeRef @ Ref.Term)
     ]
 
   , testGroup "dec_imp . enc_imp = canon_imp"
-    [ testProperty "Term"    (prop_encodeImpdecodeImp @ Ref.Term)
+    [ testProperty "Word8"   (prop_encodeImpdecodeImp @ TokWord8)
+    , testProperty "Word16"  (prop_encodeImpdecodeImp @ TokWord16)
+    , testProperty "Word32"  (prop_encodeImpdecodeImp @ TokWord32)
+    , testProperty "Word64"  (prop_encodeImpdecodeImp @ TokWord64)
+    , testProperty "Word"    (prop_encodeImpdecodeImp @ TokWord)
+--  , testProperty "NegWord" (prop_encodeImpdecodeImp @ TokNegWord)
+    , testProperty "Int8"    (prop_encodeImpdecodeImp @ TokInt8)
+    , testProperty "Int16"   (prop_encodeImpdecodeImp @ TokInt16)
+    , testProperty "Int32"   (prop_encodeImpdecodeImp @ TokInt32)
+    , testProperty "Int64"   (prop_encodeImpdecodeImp @ TokInt64)
+    , testProperty "Int"     (prop_encodeImpdecodeImp @ TokInt)
+    , testProperty "Integer" (prop_encodeImpdecodeImp @ TokInteger)
+    , testProperty "Half"    (prop_encodeImpdecodeImp @ TokHalf)
+    , testProperty "Float"   (prop_encodeImpdecodeImp @ TokFloat)
+    , testProperty "Double"  (prop_encodeImpdecodeImp @ TokDouble)
+    , testProperty "Tag"     (prop_encodeImpdecodeImp @ TokTag)
+    , testProperty "Tag64"   (prop_encodeImpdecodeImp @ TokTag64)
+    , testProperty "Simple"  (prop_encodeImpdecodeImp @ Ref.Simple)
+    , testProperty "Term"    (prop_encodeImpdecodeImp @ Ref.Term)
     ]
 
   , testGroup "dec_imp . enc_imp = canon_imp (all 2-splits)"
-    [ localOption (QuickCheckMaxSize 100) $
+    [ testProperty "Word8"   (prop_encodeImpdecodeImp_splits2 @ TokWord8)
+    , testProperty "Word16"  (prop_encodeImpdecodeImp_splits2 @ TokWord16)
+    , testProperty "Word32"  (prop_encodeImpdecodeImp_splits2 @ TokWord32)
+    , testProperty "Word64"  (prop_encodeImpdecodeImp_splits2 @ TokWord64)
+    , testProperty "Word"    (prop_encodeImpdecodeImp_splits2 @ TokWord)
+--  , testProperty "NegWord" (prop_encodeImpdecodeImp_splits2 @ TokNegWord)
+    , testProperty "Int8"    (prop_encodeImpdecodeImp_splits2 @ TokInt8)
+    , testProperty "Int16"   (prop_encodeImpdecodeImp_splits2 @ TokInt16)
+    , testProperty "Int32"   (prop_encodeImpdecodeImp_splits2 @ TokInt32)
+    , testProperty "Int64"   (prop_encodeImpdecodeImp_splits2 @ TokInt64)
+    , testProperty "Int"     (prop_encodeImpdecodeImp_splits2 @ TokInt)
+    , testProperty "Integer" (prop_encodeImpdecodeImp_splits2 @ TokInteger)
+    , testProperty "Half"    (prop_encodeImpdecodeImp_splits2 @ TokHalf)
+    , testProperty "Float"   (prop_encodeImpdecodeImp_splits2 @ TokFloat)
+    , testProperty "Double"  (prop_encodeImpdecodeImp_splits2 @ TokDouble)
+    , testProperty "Tag"     (prop_encodeImpdecodeImp_splits2 @ TokTag)
+    , testProperty "Tag64"   (prop_encodeImpdecodeImp_splits2 @ TokTag64)
+    , testProperty "Simple"  (prop_encodeImpdecodeImp_splits2 @ Ref.Simple)
+    , localOption (QuickCheckMaxSize 100) $
       testProperty "Term"    (prop_encodeImpdecodeImp_splits2 @ Ref.Term)
     ]
 
   , testGroup "dec_imp . enc_imp = canon_imp (all 3-splits)"
-    [ localOption (QuickCheckMaxSize 25) $
+    [ testProperty "Word8"   (prop_encodeImpdecodeImp_splits3 @ TokWord8)
+    , testProperty "Word16"  (prop_encodeImpdecodeImp_splits3 @ TokWord16)
+    , testProperty "Word32"  (prop_encodeImpdecodeImp_splits3 @ TokWord32)
+    , testProperty "Word64"  (prop_encodeImpdecodeImp_splits3 @ TokWord64)
+    , testProperty "Word"    (prop_encodeImpdecodeImp_splits3 @ TokWord)
+--  , testProperty "NegWord" (prop_encodeImpdecodeImp_splits3 @ TokNegWord)
+    , testProperty "Int8"    (prop_encodeImpdecodeImp_splits3 @ TokInt8)
+    , testProperty "Int16"   (prop_encodeImpdecodeImp_splits3 @ TokInt16)
+    , testProperty "Int32"   (prop_encodeImpdecodeImp_splits3 @ TokInt32)
+    , testProperty "Int64"   (prop_encodeImpdecodeImp_splits3 @ TokInt64)
+    , testProperty "Int"     (prop_encodeImpdecodeImp_splits3 @ TokInt)
+    , testProperty "Integer" (prop_encodeImpdecodeImp_splits3 @ TokInteger)
+    , testProperty "Half"    (prop_encodeImpdecodeImp_splits3 @ TokHalf)
+    , testProperty "Float"   (prop_encodeImpdecodeImp_splits3 @ TokFloat)
+    , testProperty "Double"  (prop_encodeImpdecodeImp_splits3 @ TokDouble)
+    , testProperty "Tag"     (prop_encodeImpdecodeImp_splits3 @ TokTag)
+    , testProperty "Tag64"   (prop_encodeImpdecodeImp_splits3 @ TokTag64)
+    , testProperty "Simple"  (prop_encodeImpdecodeImp_splits3 @ Ref.Simple)
+    , localOption (QuickCheckMaxSize 25) $
       testProperty "Term"    (prop_encodeImpdecodeImp_splits3 @ Ref.Term)
     ]
 
   , testGroup "enc_imp . from = enc_ref . canon_ref"
-    [ testProperty "Term"    (prop_encodeRefencodeImp1 @ Ref.Term)
+    [ testProperty "Word8"   (prop_encodeRefencodeImp1 @ TokWord8)
+    , testProperty "Word16"  (prop_encodeRefencodeImp1 @ TokWord16)
+    , testProperty "Word32"  (prop_encodeRefencodeImp1 @ TokWord32)
+    , testProperty "Word64"  (prop_encodeRefencodeImp1 @ TokWord64)
+    , testProperty "Word"    (prop_encodeRefencodeImp1 @ TokWord)
+--  , testProperty "NegWord" (prop_encodeRefencodeImp1 @ TokNegWord)
+    , testProperty "Int8"    (prop_encodeRefencodeImp1 @ TokInt8)
+    , testProperty "Int16"   (prop_encodeRefencodeImp1 @ TokInt16)
+    , testProperty "Int32"   (prop_encodeRefencodeImp1 @ TokInt32)
+    , testProperty "Int64"   (prop_encodeRefencodeImp1 @ TokInt64)
+    , testProperty "Int"     (prop_encodeRefencodeImp1 @ TokInt)
+    , testProperty "Integer" (prop_encodeRefencodeImp1 @ TokInteger)
+    , testProperty "Half"    (prop_encodeRefencodeImp1 @ TokHalf)
+    , testProperty "Float"   (prop_encodeRefencodeImp1 @ TokFloat)
+    , testProperty "Double"  (prop_encodeRefencodeImp1 @ TokDouble)
+    , testProperty "Tag"     (prop_encodeRefencodeImp1 @ TokTag)
+    , testProperty "Tag64"   (prop_encodeRefencodeImp1 @ TokTag64)
+    , testProperty "Simple"  (prop_encodeRefencodeImp1 @ Ref.Simple)
+    , testProperty "Term"    (prop_encodeRefencodeImp1 @ Ref.Term)
     ]
 
   , testGroup "enc_ref . to = enc_imp"
-    [ testProperty "Term"    (prop_encodeRefencodeImp2 @ Ref.Term)
+    [ testProperty "Word8"   (prop_encodeRefencodeImp2 @ TokWord8)
+    , testProperty "Word16"  (prop_encodeRefencodeImp2 @ TokWord16)
+    , testProperty "Word32"  (prop_encodeRefencodeImp2 @ TokWord32)
+    , testProperty "Word64"  (prop_encodeRefencodeImp2 @ TokWord64)
+    , testProperty "Word"    (prop_encodeRefencodeImp2 @ TokWord)
+--  , testProperty "NegWord" (prop_encodeRefencodeImp2 @ TokNegWord)
+    , testProperty "Int8"    (prop_encodeRefencodeImp2 @ TokInt8)
+    , testProperty "Int16"   (prop_encodeRefencodeImp2 @ TokInt16)
+    , testProperty "Int32"   (prop_encodeRefencodeImp2 @ TokInt32)
+    , testProperty "Int64"   (prop_encodeRefencodeImp2 @ TokInt64)
+    , testProperty "Int"     (prop_encodeRefencodeImp2 @ TokInt)
+    , testProperty "Integer" (prop_encodeRefencodeImp2 @ TokInteger)
+    , testProperty "Half"    (prop_encodeRefencodeImp2 @ TokHalf)
+    , testProperty "Float"   (prop_encodeRefencodeImp2 @ TokFloat)
+    , testProperty "Double"  (prop_encodeRefencodeImp2 @ TokDouble)
+    , testProperty "Tag"     (prop_encodeRefencodeImp2 @ TokTag)
+    , testProperty "Tag64"   (prop_encodeRefencodeImp2 @ TokTag64)
+    , testProperty "Simple"  (prop_encodeRefencodeImp2 @ Ref.Simple)
+    , testProperty "Term"    (prop_encodeRefencodeImp2 @ Ref.Term)
     ]
 
   , testGroup "dec_imp . enc_ref = from . dec_ref . enc_ref"
-    [ testProperty "Term"    (prop_decodeRefdecodeImp @ Ref.Term)
+    [ testProperty "Word8"   (prop_decodeRefdecodeImp @ TokWord8)
+    , testProperty "Word16"  (prop_decodeRefdecodeImp @ TokWord16)
+    , testProperty "Word32"  (prop_decodeRefdecodeImp @ TokWord32)
+    , testProperty "Word64"  (prop_decodeRefdecodeImp @ TokWord64)
+    , testProperty "Word"    (prop_decodeRefdecodeImp @ TokWord)
+--  , testProperty "NegWord" (prop_decodeRefdecodeImp @ TokNegWord)
+    , testProperty "Int8"    (prop_decodeRefdecodeImp @ TokInt8)
+    , testProperty "Int16"   (prop_decodeRefdecodeImp @ TokInt16)
+    , testProperty "Int32"   (prop_decodeRefdecodeImp @ TokInt32)
+    , testProperty "Int64"   (prop_decodeRefdecodeImp @ TokInt64)
+    , testProperty "Int"     (prop_decodeRefdecodeImp @ TokInt)
+    , testProperty "Integer" (prop_decodeRefdecodeImp @ TokInteger)
+    , testProperty "Half"    (prop_decodeRefdecodeImp @ TokHalf)
+    , testProperty "Float"   (prop_decodeRefdecodeImp @ TokFloat)
+    , testProperty "Double"  (prop_decodeRefdecodeImp @ TokDouble)
+    , testProperty "Tag"     (prop_decodeRefdecodeImp @ TokTag)
+    , testProperty "Tag64"   (prop_decodeRefdecodeImp @ TokTag64)
+    , testProperty "Simple"  (prop_decodeRefdecodeImp @ Ref.Simple)
+    , testProperty "Term"    (prop_decodeRefdecodeImp @ Ref.Term)
     ]
   ]

--- a/cborg/tests/Tests/Properties.hs
+++ b/cborg/tests/Tests/Properties.hs
@@ -24,11 +24,8 @@ import           Test.Tasty.QuickCheck (testProperty, QuickCheckMaxSize(..))
 import           Test.QuickCheck
 
 import qualified Tests.Reference.Implementation as Ref
-import qualified Tests.Term as Term (serialise, deserialise)
 import           Tests.Term
-                   ( fromRefTerm, toRefTerm, eqTerm
-                   , prop_toFromRefTerm, prop_fromToRefTerm
-                   , canonicaliseTerm )
+                   ( fromRefTerm, toRefTerm, eqTerm, canonicaliseTerm )
 import           Tests.Util
 
 #if !MIN_VERSION_base(4,8,0)
@@ -323,62 +320,6 @@ prop_decodeRefdecodeImp x =
 
 
 --------------------------------------------------------------------------------
--- Properties
---
-
-prop_encodeDecodeTermRoundtrip :: Term -> Bool
-prop_encodeDecodeTermRoundtrip term =
-             (Term.deserialise . Term.serialise) term
-    `eqTerm` canonicaliseTerm term
-
-prop_encodeDecodeTermRoundtrip_splits2 :: Term -> Bool
-prop_encodeDecodeTermRoundtrip_splits2 term =
-    and [          Term.deserialise thedata'
-          `eqTerm` canonicaliseTerm term
-        | let thedata = Term.serialise term
-        , thedata' <- splits2 thedata ]
-
-prop_encodeDecodeTermRoundtrip_splits3 :: Term -> Bool
-prop_encodeDecodeTermRoundtrip_splits3 term =
-    and [          Term.deserialise thedata'
-          `eqTerm` canonicaliseTerm term
-        | let thedata = Term.serialise term
-        , thedata' <- splits3 thedata ]
-
-prop_encodeTermMatchesRefImpl :: Ref.Term -> Bool
-prop_encodeTermMatchesRefImpl term =
-    let encoded  = Term.serialise (fromRefTerm term)
-        encoded' = Ref.serialise (Ref.canonicaliseTerm term)
-     in encoded == encoded'
-
-prop_encodeTermMatchesRefImpl2 :: Term -> Bool
-prop_encodeTermMatchesRefImpl2 term =
-    let encoded  = Term.serialise term
-        encoded' = Ref.serialise (toRefTerm term)
-     in encoded == encoded'
-
-prop_decodeTermMatchesRefImpl :: Ref.Term -> Bool
-prop_decodeTermMatchesRefImpl term0 =
-    let encoded = Ref.serialise term0
-        term    = Ref.deserialise encoded
-        term'   = Term.deserialise encoded
-     in term' `eqTerm` fromRefTerm term
-
-prop_decodeTermNonCanonical :: Ref.Term -> Property
-prop_decodeTermNonCanonical term0 =
-    let encoded = Ref.serialise term0
-        term    = Ref.deserialise encoded
-        term'   = Term.deserialise encoded
-        encoded'= Term.serialise term'
-        isCanonical = encoded == encoded'
-     in not isCanonical ==>
-        -- This property holds without this pre-condition, as demonstrated by
-        -- prop_decodeTermMatchesRefImpl, but using it ensures we get good
-        -- coverage of the non-canonical cases
-        term' `eqTerm` fromRefTerm term
-
-
---------------------------------------------------------------------------------
 -- Token class instances for Term type
 --
 
@@ -442,22 +383,5 @@ testTree =
 
   , testGroup "dec_imp . enc_ref = from . dec_ref . enc_ref"
     [ testProperty "Term"    (prop_decodeRefdecodeImp @ Ref.Term)
-    ]
-
-  , testGroup "Terms"
-    [ testProperty "from/to reference terms"        prop_fromToRefTerm
-    , testProperty "to/from reference terms"        prop_toFromRefTerm
-    , testProperty "rountrip de/encoding terms"     prop_encodeDecodeTermRoundtrip
-      -- TODO FIXME: need to fix the generation of terms to give
-      -- better size distribution some get far too big for the
-      -- splits properties.
-    , localOption (QuickCheckMaxSize 30) $
-      testProperty "decoding with all 2-chunks"     prop_encodeDecodeTermRoundtrip_splits2
-    , localOption (QuickCheckMaxSize 20) $
-      testProperty "decoding with all 3-chunks"     prop_encodeDecodeTermRoundtrip_splits3
-    , testProperty "encode term matches ref impl 1" prop_encodeTermMatchesRefImpl
-    , testProperty "encode term matches ref impl 2" prop_encodeTermMatchesRefImpl2
-    , testProperty "decoding term matches ref impl" prop_decodeTermMatchesRefImpl
-    , testProperty "non-canonical encoding"         prop_decodeTermNonCanonical
     ]
   ]

--- a/cborg/tests/Tests/Properties.hs
+++ b/cborg/tests/Tests/Properties.hs
@@ -3,8 +3,6 @@
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE DefaultSignatures    #-}
-{-# LANGUAGE AllowAmbiguousTypes  #-}
-{-# LANGUAGE TypeApplications     #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Tests.Properties (
@@ -46,6 +44,7 @@ import           Data.Int
 import           Data.Bits (complement)
 import qualified Numeric.Half as Half
 import           Data.Function (on)
+import           Data.Proxy
 
 import           Codec.CBOR.Term
 import           Codec.CBOR.Read
@@ -102,26 +101,28 @@ import           Control.Applicative
 class (Eq t, Show t) => Token t where
   type Imp t :: *
 
-  encodeImp :: Imp t -> Encoding
+  encodeImp :: Proxy t -> Imp t -> Encoding
   encodeRef :: Ref.Encoder t
 
-  decodeImp :: forall s. Decoder s (Imp t)
-  decodeRef :: Ref.Decoder t
+  decodeImp :: forall s. Proxy t -> Decoder s (Imp t)
+  decodeRef :: Proxy t -> Ref.Decoder t
 
-  canonicaliseImp :: Imp t -> Imp t
-  canonicaliseRef ::     t ->     t
+  canonicaliseImp :: Proxy t -> Imp t -> Imp t
+  canonicaliseRef ::                t ->     t
 
-  eqImp   :: Imp t -> Imp t -> Bool
+  eqImp   :: Proxy t -> Imp t -> Imp t -> Bool
 
-  toRef   :: Imp t -> t
-  fromRef :: t -> Imp t
+  toRef   :: Proxy t -> Imp t -> t
+  fromRef ::            t -> Imp t
 
   -- defaults
-  canonicaliseImp = id
-  canonicaliseRef = toRef . fromRef
+  canonicaliseImp _ = id
+  canonicaliseRef   = toRef t . fromRef
+    where
+      t  = Proxy :: Proxy t
 
-  default eqImp :: Eq (Imp t) => Imp t -> Imp t -> Bool
-  eqImp = (==)
+  default eqImp :: Eq (Imp t) => Proxy t -> Imp t -> Imp t -> Bool
+  eqImp _ = (==)
 
 
 -- A few derived utils
@@ -129,24 +130,30 @@ class (Eq t, Show t) => Token t where
 serialiseRef :: forall t. Token t => t -> LBS.ByteString
 serialiseRef = LBS.pack . encodeRef
 
-serialiseImp :: forall t. Token t => Imp t -> LBS.ByteString
-serialiseImp = toLazyByteString . encodeImp @t
+serialiseImp :: forall t. Token t => Proxy t -> Imp t -> LBS.ByteString
+serialiseImp _ = toLazyByteString . encodeImp t
+  where
+    t  = Proxy :: Proxy t
 
-deserialiseRef :: forall t. Token t => LBS.ByteString -> t
-deserialiseRef bytes =
-  case Ref.runDecoder (decodeRef @t) (LBS.unpack bytes) of
+deserialiseRef :: forall t. Token t => Proxy t -> LBS.ByteString -> t
+deserialiseRef _ bytes =
+  case Ref.runDecoder (decodeRef t) (LBS.unpack bytes) of
     Just (x, trailing)
       | null trailing -> x
       | otherwise     -> error "deserialiseRef: trailing bytes"
     Nothing           -> error "deserialiseRef: decode failure"
+  where
+    t  = Proxy :: Proxy t
 
-deserialiseImp :: forall t. Token t => LBS.ByteString -> Imp t
-deserialiseImp bytes =
-    case deserialiseFromBytes (decodeImp @ t) bytes of
+deserialiseImp :: forall t. Token t => Proxy t -> LBS.ByteString -> Imp t
+deserialiseImp _ bytes =
+    case deserialiseFromBytes (decodeImp t) bytes of
       Right (trailing, x)
         | LBS.null trailing -> x
         | otherwise         -> error "deserialiseImp: trailing data"
       Left _failure         -> error "deserialiseImp: decode failure"
+  where
+    t  = Proxy :: Proxy t
 
 
 --------------------------------------------------------------------------------
@@ -170,10 +177,13 @@ deserialiseImp bytes =
 --
 -- > to . id . from = canon_ref
 --
-prop_fromRefToRef :: Token t => t -> Bool
-prop_fromRefToRef x =
+prop_fromRefToRef :: Token t => Proxy t -> t -> Bool
+prop_fromRefToRef _ x =
 
-    (toRef . fromRef) x == canonicaliseRef x
+    (toRef t . fromRef) x == canonicaliseRef x
+
+  where
+    t  = Proxy :: Proxy t
 
 
 -- | The property corresponding to the following part of the commuting diagram.
@@ -192,13 +202,14 @@ prop_fromRefToRef x =
 --
 -- > from . id . to = canon_imp
 --
-prop_toRefFromRef :: forall t. Token t => Imp t -> Bool
-prop_toRefFromRef x =
+prop_toRefFromRef :: forall t. Token t => Proxy t -> Imp t -> Bool
+prop_toRefFromRef _ x =
 
-    (fromRef . toRef @t) x  `eq`  canonicaliseImp @t x
+    (fromRef . toRef t) x  `eq`  canonicaliseImp t x
 
   where
-    eq = eqImp @t
+    eq = eqImp t
+    t  = Proxy :: Proxy t
 
 
 -- | The property corresponding to the following part of the commuting diagram.
@@ -219,10 +230,13 @@ prop_toRefFromRef x =
 --
 -- > dec_ref . enc_ref = id
 --
-prop_encodeRefdecodeRef :: forall t. Token t => t -> Bool
-prop_encodeRefdecodeRef x =
+prop_encodeRefdecodeRef :: forall t. Token t => Proxy t -> t -> Bool
+prop_encodeRefdecodeRef _ x =
 
-    (deserialiseRef . serialiseRef) x  ==  x
+    (deserialiseRef t . serialiseRef) x  ==  x
+
+  where
+    t  = Proxy :: Proxy t
 
 
 -- | The property corresponding to the following part of the commuting diagram.
@@ -243,13 +257,14 @@ prop_encodeRefdecodeRef x =
 --
 -- > dec_imp . enc_imp = canon_imp
 --
-prop_encodeImpdecodeImp :: forall t. Token t => Imp t -> Bool
-prop_encodeImpdecodeImp x =
+prop_encodeImpdecodeImp :: forall t. Token t => Proxy t -> Imp t -> Bool
+prop_encodeImpdecodeImp _ x =
 
-    (deserialiseImp @t . serialiseImp @t) x  `eq`  canonicaliseImp @t x
+    (deserialiseImp t . serialiseImp t) x  `eq`  canonicaliseImp t x
 
   where
-    eq = eqImp @t
+    eq = eqImp t
+    t  = Proxy :: Proxy t
 
 
 -- | This is the same property as 'prop_encodeImpdecodeImp' but the encoded
@@ -257,28 +272,30 @@ prop_encodeImpdecodeImp x =
 -- possible 2-chunk splits are tried. This checks that the decoder gives the
 -- same result irrespective of the chunk boundaries.
 --
-prop_encodeImpdecodeImp_splits2 :: forall t. Token t => Imp t -> Bool
-prop_encodeImpdecodeImp_splits2 x =
-    and [ deserialiseImp @t enc'  `eq`  x'
-        | let enc = serialiseImp    @t x
-              x'  = canonicaliseImp @t x
+prop_encodeImpdecodeImp_splits2 :: forall t. Token t => Proxy t -> Imp t -> Bool
+prop_encodeImpdecodeImp_splits2 _ x =
+    and [ deserialiseImp t enc'  `eq`  x'
+        | let enc = serialiseImp    t x
+              x'  = canonicaliseImp t x
         , enc' <- splits2 enc ]
   where
-    eq = eqImp @t
+    eq = eqImp t
+    t  = Proxy :: Proxy t
 
 
 -- | This is the same idea as 'prop_encodeImpdecodeImp_splits2' but with all
 -- possible 3-chunk splits of the input data. This test is of course more
 -- expensive and so the size of the input must be limited.
 --
-prop_encodeImpdecodeImp_splits3 :: forall t. Token t => Imp t -> Bool
-prop_encodeImpdecodeImp_splits3 x =
-    and [ deserialiseImp @t enc'  `eq`  x'
-        | let enc = serialiseImp    @t x
-              x'  = canonicaliseImp @t x
+prop_encodeImpdecodeImp_splits3 :: forall t. Token t => Proxy t -> Imp t -> Bool
+prop_encodeImpdecodeImp_splits3 _ x =
+    and [ deserialiseImp t enc'  `eq`  x'
+        | let enc = serialiseImp    t x
+              x'  = canonicaliseImp t x
         , enc' <- splits3 enc ]
   where
-    eq = eqImp @t
+    eq = eqImp t
+    t  = Proxy :: Proxy t
 
 
 -- | The property corresponding to the following part of the commuting diagram.
@@ -300,10 +317,13 @@ prop_encodeImpdecodeImp_splits3 x =
 --
 -- > enc_imp . id . from = enc_ref . canon_ref
 --
-prop_encodeRefencodeImp1 :: forall t. Token t => t -> Bool
-prop_encodeRefencodeImp1 x =
+prop_encodeRefencodeImp1 :: forall t. Token t => Proxy t -> t -> Bool
+prop_encodeRefencodeImp1 _ x =
 
-    (serialiseImp @t . fromRef) x  ==  (serialiseRef . canonicaliseRef) x
+    (serialiseImp t . fromRef) x  ==  (serialiseRef . canonicaliseRef) x
+
+  where
+    t  = Proxy :: Proxy t
 
 
 -- | The property corresponding to the following part of the commuting diagram.
@@ -323,10 +343,13 @@ prop_encodeRefencodeImp1 x =
 --
 -- > enc_ref . id . to = enc_imp
 --
-prop_encodeRefencodeImp2 :: forall t. Token t => Imp t -> Bool
-prop_encodeRefencodeImp2 x =
+prop_encodeRefencodeImp2 :: forall t. Token t => Proxy t -> Imp t -> Bool
+prop_encodeRefencodeImp2 _ x =
 
-    (serialiseRef . toRef @t) x == serialiseImp @t x
+    (serialiseRef . toRef t) x == serialiseImp t x
+
+  where
+    t  = Proxy :: Proxy t
 
 
 -- | The property corresponding to the following part of the commuting diagram.
@@ -346,14 +369,15 @@ prop_encodeRefencodeImp2 x =
 --
 -- > dec_imp . enc_ref = from . dec_ref . enc_ref
 --
-prop_decodeRefdecodeImp :: forall t. Token t => t -> Bool
-prop_decodeRefdecodeImp x =
+prop_decodeRefdecodeImp :: forall t. Token t => Proxy t -> t -> Bool
+prop_decodeRefdecodeImp _ x =
 
-    deserialiseImp @t enc  `eq`  (fromRef . deserialiseRef @t) enc
+    deserialiseImp t enc  `eq`  (fromRef . deserialiseRef t) enc
 
   where
     enc = serialiseRef x
-    eq  = eqImp @t
+    eq  = eqImp t
+    t   = Proxy :: Proxy t
 
 
 --------------------------------------------------------------------------------
@@ -367,14 +391,14 @@ instance Token TokWord8 where
     type Imp TokWord8 = Word8
 
     fromRef = fromIntegral . Ref.fromUInt . unTokWord8
-    toRef   = TokWord8 . Ref.toUInt . fromIntegral
+    toRef _ = TokWord8 . Ref.toUInt . fromIntegral
 
-    encodeImp = encodeWord8
-    decodeImp = decodeWord8
+    encodeImp _ = encodeWord8
+    decodeImp _ = decodeWord8
 
     encodeRef (TokWord8 n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
-    decodeRef = do Ref.MT0_UnsignedInt n <- Ref.decodeToken
-                   return (TokWord8 n)
+    decodeRef _ = do Ref.MT0_UnsignedInt n <- Ref.decodeToken
+                     return (TokWord8 n)
 
 instance Arbitrary TokWord8 where
     arbitrary = TokWord8 <$> oneof arbitraryUInt_Word8
@@ -393,14 +417,14 @@ instance Token TokWord16 where
     type Imp TokWord16 = Word16
 
     fromRef = fromIntegral . Ref.fromUInt . unTokWord16
-    toRef   = TokWord16 . Ref.toUInt . fromIntegral
+    toRef _ = TokWord16 . Ref.toUInt . fromIntegral
 
-    encodeImp = encodeWord16
-    decodeImp = decodeWord16
+    encodeImp _ = encodeWord16
+    decodeImp _ = decodeWord16
 
     encodeRef (TokWord16 n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
-    decodeRef = do Ref.MT0_UnsignedInt n <- Ref.decodeToken
-                   return (TokWord16 n)
+    decodeRef _ = do Ref.MT0_UnsignedInt n <- Ref.decodeToken
+                     return (TokWord16 n)
 
 instance Arbitrary TokWord16 where
       arbitrary = TokWord16 <$> oneof arbitraryUInt_Word16
@@ -420,14 +444,14 @@ instance Token TokWord32 where
     type Imp TokWord32 = Word32
 
     fromRef = fromIntegral . Ref.fromUInt . unTokWord32
-    toRef   = TokWord32 . Ref.toUInt . fromIntegral
+    toRef _ = TokWord32 . Ref.toUInt . fromIntegral
 
-    encodeImp = encodeWord32
-    decodeImp = decodeWord32
+    encodeImp _ = encodeWord32
+    decodeImp _ = decodeWord32
 
     encodeRef (TokWord32 n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
-    decodeRef = do Ref.MT0_UnsignedInt n <- Ref.decodeToken
-                   return (TokWord32 n)
+    decodeRef _ = do Ref.MT0_UnsignedInt n <- Ref.decodeToken
+                     return (TokWord32 n)
 
 instance Arbitrary TokWord32 where
     arbitrary = TokWord32 <$> oneof arbitraryUInt_Word32
@@ -447,14 +471,14 @@ instance Token TokWord64 where
     type Imp TokWord64 = Word64
 
     fromRef = fromIntegral . Ref.fromUInt . unTokWord64
-    toRef   = TokWord64 . Ref.toUInt . fromIntegral
+    toRef _ = TokWord64 . Ref.toUInt . fromIntegral
 
-    encodeImp = encodeWord64
-    decodeImp = decodeWord64
+    encodeImp _ = encodeWord64
+    decodeImp _ = decodeWord64
 
     encodeRef (TokWord64 n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
-    decodeRef = do Ref.MT0_UnsignedInt n <- Ref.decodeToken
-                   return (TokWord64 n)
+    decodeRef _ = do Ref.MT0_UnsignedInt n <- Ref.decodeToken
+                     return (TokWord64 n)
 
 instance Arbitrary TokWord64 where
     arbitrary = TokWord64 <$> oneof arbitraryUInt_Word64
@@ -490,14 +514,14 @@ instance Token TokWord where
     type Imp TokWord = Word
 
     fromRef = fromIntegral . Ref.fromUInt . unTokWord
-    toRef   = TokWord . Ref.toUInt . fromIntegral
+    toRef _ = TokWord . Ref.toUInt . fromIntegral
 
-    encodeImp = encodeWord
-    decodeImp = decodeWord
+    encodeImp _ = encodeWord
+    decodeImp _ = decodeWord
 
     encodeRef (TokWord n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
-    decodeRef = do Ref.MT0_UnsignedInt n <- Ref.decodeToken
-                   return (TokWord n)
+    decodeRef _ = do Ref.MT0_UnsignedInt n <- Ref.decodeToken
+                     return (TokWord n)
 
 
 --------------------------------------------------------------------------------
@@ -513,20 +537,22 @@ instance Token TokInt8 where
 
     fromRef (TokInt8 True  n) =              (fromIntegral . Ref.fromUInt) n
     fromRef (TokInt8 False n) = (complement . fromIntegral . Ref.fromUInt) n
-    toRef n | n >= 0    = TokInt8 True  ((Ref.toUInt . fromIntegral) n)
-            | otherwise = TokInt8 False ((Ref.toUInt . fromIntegral . complement) n)
+    toRef _ n
+      | n >= 0    = TokInt8 True  ((Ref.toUInt . fromIntegral) n)
+      | otherwise = TokInt8 False ((Ref.toUInt . fromIntegral . complement) n)
 
-    encodeImp = encodeInt8
-    decodeImp = decodeInt8
+    encodeImp _ = encodeInt8
+    decodeImp _ = decodeInt8
 
     encodeRef (TokInt8 True  n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
     encodeRef (TokInt8 False n) = Ref.encodeToken (Ref.MT1_NegativeInt n)
 
-    decodeRef = do tok <- Ref.decodeToken
-                   case tok of
-                     Ref.MT0_UnsignedInt n -> return (TokInt8 True  n)
-                     Ref.MT1_NegativeInt n -> return (TokInt8 False n)
-                     _                     -> fail "decodeRef (TokInt)"
+    decodeRef _ = do
+      tok <- Ref.decodeToken
+      case tok of
+        Ref.MT0_UnsignedInt n -> return (TokInt8 True  n)
+        Ref.MT1_NegativeInt n -> return (TokInt8 False n)
+        _                     -> fail "decodeRef (TokInt)"
 
 instance Arbitrary TokInt8 where
     arbitrary = TokInt8 <$> arbitrary <*> oneof arbitraryUInt_Int8
@@ -548,20 +574,22 @@ instance Token TokInt16 where
 
     fromRef (TokInt16 True  n) =              (fromIntegral . Ref.fromUInt) n
     fromRef (TokInt16 False n) = (complement . fromIntegral . Ref.fromUInt) n
-    toRef n | n >= 0    = TokInt16 True  ((Ref.toUInt . fromIntegral) n)
-            | otherwise = TokInt16 False ((Ref.toUInt . fromIntegral . complement) n)
+    toRef _ n
+      | n >= 0    = TokInt16 True  ((Ref.toUInt . fromIntegral) n)
+      | otherwise = TokInt16 False ((Ref.toUInt . fromIntegral . complement) n)
 
-    encodeImp = encodeInt16
-    decodeImp = decodeInt16
+    encodeImp _ = encodeInt16
+    decodeImp _ = decodeInt16
 
     encodeRef (TokInt16 True  n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
     encodeRef (TokInt16 False n) = Ref.encodeToken (Ref.MT1_NegativeInt n)
 
-    decodeRef = do tok <- Ref.decodeToken
-                   case tok of
-                     Ref.MT0_UnsignedInt n -> return (TokInt16 True  n)
-                     Ref.MT1_NegativeInt n -> return (TokInt16 False n)
-                     _                     -> fail "decodeRef (TokInt16)"
+    decodeRef _ = do
+      tok <- Ref.decodeToken
+      case tok of
+        Ref.MT0_UnsignedInt n -> return (TokInt16 True  n)
+        Ref.MT1_NegativeInt n -> return (TokInt16 False n)
+        _                     -> fail "decodeRef (TokInt16)"
 
 
 instance Arbitrary TokInt16 where
@@ -583,20 +611,22 @@ instance Token TokInt32 where
 
     fromRef (TokInt32 True  n) =              (fromIntegral . Ref.fromUInt) n
     fromRef (TokInt32 False n) = (complement . fromIntegral . Ref.fromUInt) n
-    toRef n | n >= 0    = TokInt32 True  ((Ref.toUInt . fromIntegral) n)
-            | otherwise = TokInt32 False ((Ref.toUInt . fromIntegral . complement) n)
+    toRef _ n
+      | n >= 0    = TokInt32 True  ((Ref.toUInt . fromIntegral) n)
+      | otherwise = TokInt32 False ((Ref.toUInt . fromIntegral . complement) n)
 
-    encodeImp = encodeInt32
-    decodeImp = decodeInt32
+    encodeImp _ = encodeInt32
+    decodeImp _ = decodeInt32
 
     encodeRef (TokInt32 True  n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
     encodeRef (TokInt32 False n) = Ref.encodeToken (Ref.MT1_NegativeInt n)
 
-    decodeRef = do tok <- Ref.decodeToken
-                   case tok of
-                     Ref.MT0_UnsignedInt n -> return (TokInt32 True  n)
-                     Ref.MT1_NegativeInt n -> return (TokInt32 False n)
-                     _                     -> fail "decodeRef (TokInt32)"
+    decodeRef _ = do
+      tok <- Ref.decodeToken
+      case tok of
+        Ref.MT0_UnsignedInt n -> return (TokInt32 True  n)
+        Ref.MT1_NegativeInt n -> return (TokInt32 False n)
+        _                     -> fail "decodeRef (TokInt32)"
 
 instance Arbitrary TokInt32 where
     arbitrary = TokInt32 <$> arbitrary <*> oneof arbitraryUInt_Int32
@@ -618,20 +648,22 @@ instance Token TokInt64 where
 
     fromRef (TokInt64 True  n) =              (fromIntegral . Ref.fromUInt) n
     fromRef (TokInt64 False n) = (complement . fromIntegral . Ref.fromUInt) n
-    toRef n | n >= 0    = TokInt64 True  ((Ref.toUInt . fromIntegral) n)
-            | otherwise = TokInt64 False ((Ref.toUInt . fromIntegral . complement) n)
+    toRef _ n
+      | n >= 0    = TokInt64 True  ((Ref.toUInt . fromIntegral) n)
+      | otherwise = TokInt64 False ((Ref.toUInt . fromIntegral . complement) n)
 
-    encodeImp = encodeInt64
-    decodeImp = decodeInt64
+    encodeImp _ = encodeInt64
+    decodeImp _ = decodeInt64
 
     encodeRef (TokInt64 True  n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
     encodeRef (TokInt64 False n) = Ref.encodeToken (Ref.MT1_NegativeInt n)
 
-    decodeRef = do tok <- Ref.decodeToken
-                   case tok of
-                     Ref.MT0_UnsignedInt n -> return (TokInt64 True  n)
-                     Ref.MT1_NegativeInt n -> return (TokInt64 False n)
-                     _                     -> fail "decodeRef (TokInt64)"
+    decodeRef _ = do
+      tok <- Ref.decodeToken
+      case tok of
+        Ref.MT0_UnsignedInt n -> return (TokInt64 True  n)
+        Ref.MT1_NegativeInt n -> return (TokInt64 False n)
+        _                     -> fail "decodeRef (TokInt64)"
 
 instance Arbitrary TokInt64 where
     arbitrary = TokInt64 <$> arbitrary <*> oneof arbitraryUInt_Int64
@@ -654,20 +686,22 @@ instance Token TokInt where
 
     fromRef (TokInt True  n) =              (fromIntegral . Ref.fromUInt) n
     fromRef (TokInt False n) = (complement . fromIntegral . Ref.fromUInt) n
-    toRef n | n >= 0    = TokInt True  ((Ref.toUInt . fromIntegral) n)
-            | otherwise = TokInt False ((Ref.toUInt . fromIntegral . complement) n)
+    toRef _ n
+      | n >= 0    = TokInt True  ((Ref.toUInt . fromIntegral) n)
+      | otherwise = TokInt False ((Ref.toUInt . fromIntegral . complement) n)
 
-    encodeImp = encodeInt
-    decodeImp = decodeInt
+    encodeImp _ = encodeInt
+    decodeImp _ = decodeInt
 
     encodeRef (TokInt True  n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
     encodeRef (TokInt False n) = Ref.encodeToken (Ref.MT1_NegativeInt n)
 
-    decodeRef = do tok <- Ref.decodeToken
-                   case tok of
-                     Ref.MT0_UnsignedInt n -> return (TokInt True  n)
-                     Ref.MT1_NegativeInt n -> return (TokInt False n)
-                     _                     -> fail "decodeRef (TokInt)"
+    decodeRef _ = do
+      tok <- Ref.decodeToken
+      case tok of
+        Ref.MT0_UnsignedInt n -> return (TokInt True  n)
+        Ref.MT1_NegativeInt n -> return (TokInt False n)
+        _                     -> fail "decodeRef (TokInt)"
 
 instance Arbitrary TokInt where
     arbitrary = TokInt <$> arbitrary <*> oneof arbitraryUInt_Int
@@ -703,22 +737,23 @@ instance Token TokInteger where
     fromRef (TokIntegerNInt n) = (complement . fromIntegral . Ref.fromUInt) n
     fromRef (TokIntegerBig  n) = getLargeInteger n
 
-    toRef n | n >= 0 && n <= fromIntegral (maxBound :: Word64)
-            = TokIntegerUInt ((Ref.toUInt . fromIntegral) n)
+    toRef _ n
+      | n >= 0 && n <= fromIntegral (maxBound :: Word64)
+      = TokIntegerUInt ((Ref.toUInt . fromIntegral) n)
 
-            | n < 0  && complement n <= fromIntegral (maxBound :: Word64)
-            = TokIntegerNInt ((Ref.toUInt . fromIntegral . complement) n)
+      | n < 0  && complement n <= fromIntegral (maxBound :: Word64)
+      = TokIntegerNInt ((Ref.toUInt . fromIntegral . complement) n)
 
-            | otherwise = TokIntegerBig (LargeInteger n)
+      | otherwise = TokIntegerBig (LargeInteger n)
 
-    encodeImp = encodeInteger
-    decodeImp = decodeInteger
+    encodeImp _ = encodeInteger
+    decodeImp _ = decodeInteger
 
     encodeRef (TokIntegerUInt n) = Ref.encodeToken (Ref.MT0_UnsignedInt n)
     encodeRef (TokIntegerNInt n) = Ref.encodeToken (Ref.MT1_NegativeInt n)
     encodeRef (TokIntegerBig  n) = Ref.encodeTerm (Ref.TBigInt (getLargeInteger n))
 
-    decodeRef = do
+    decodeRef _ = do
       tok <- Ref.decodeToken
       case tok of
         Ref.MT0_UnsignedInt n -> return (TokIntegerUInt  n)
@@ -769,25 +804,25 @@ instance Arbitrary TokHalf where
 instance Token TokHalf where
     type Imp TokHalf = Float
 
-    eqImp = (==) `on` floatToWord
+    eqImp _ = (==) `on` floatToWord
 
     fromRef (TokHalf (HalfSpecials n)) = Half.fromHalf n
-    toRef = TokHalf
-          . canonicaliseNaN
-          . HalfSpecials
-          . Half.toHalf
+    toRef _ = TokHalf
+            . canonicaliseNaN
+            . HalfSpecials
+            . Half.toHalf
 
-    canonicaliseImp = Half.fromHalf
-                    . canonicaliseNaN
-                    . Half.toHalf
+    canonicaliseImp _ = Half.fromHalf
+                      . canonicaliseNaN
+                      . Half.toHalf
     canonicaliseRef (TokHalf n) = TokHalf (canonicaliseNaN n)
 
-    encodeImp = encodeFloat16
-    decodeImp = decodeFloat
+    encodeImp _ = encodeFloat16
+    decodeImp _ = decodeFloat
 
     encodeRef (TokHalf n) = Ref.encodeToken (Ref.MT7_Float16 n)
-    decodeRef = do Ref.MT7_Float16 n <- Ref.decodeToken
-                   return (TokHalf n)
+    decodeRef _ = do Ref.MT7_Float16 n <- Ref.decodeToken
+                     return (TokHalf n)
 
 data TokFloat = TokFloat FloatSpecials
               | TokFloatNan
@@ -799,33 +834,34 @@ instance Arbitrary TokFloat where
 instance Token TokFloat where
     type Imp TokFloat = Float
 
-    eqImp = (==) `on` floatToWord
+    eqImp _ = (==) `on` floatToWord
 
     fromRef (TokFloat n) = getFloatSpecials n
     fromRef TokFloatNan  = canonicalNaN
-    toRef n
+    toRef _ n
       | isNaN n   = TokFloatNan
       | otherwise = TokFloat (FloatSpecials n)
 
-    canonicaliseImp = canonicaliseNaN
+    canonicaliseImp _ = canonicaliseNaN
 
     canonicaliseRef TokFloatNan = TokFloatNan
     canonicaliseRef (TokFloat (FloatSpecials n))
       | isNaN n   = TokFloatNan
       | otherwise = TokFloat (FloatSpecials n)
 
-    encodeImp = encodeFloat
-    decodeImp = decodeFloat
+    encodeImp _ = encodeFloat
+    decodeImp _ = decodeFloat
 
     encodeRef (TokFloat n) = Ref.encodeToken (Ref.MT7_Float32 n)
     encodeRef TokFloatNan  = Ref.encodeToken (Ref.MT7_Float16 canonicalNaN)
 
-    decodeRef = do tok <- Ref.decodeToken
-                   case tok of
-                     Ref.MT7_Float16 n | isNaN n
-                                       -> return TokFloatNan
-                     Ref.MT7_Float32 n -> return (TokFloat n)
-                     _                 -> fail "decodeRef (TokFloat)"
+    decodeRef _ = do
+      tok <- Ref.decodeToken
+      case tok of
+        Ref.MT7_Float16 n  | isNaN n
+                          -> return TokFloatNan
+        Ref.MT7_Float32 n -> return (TokFloat n)
+        _                 -> fail "decodeRef (TokFloat)"
 
 
 data TokDouble = TokDouble DoubleSpecials
@@ -838,32 +874,33 @@ instance Arbitrary TokDouble where
 instance Token TokDouble where
     type Imp TokDouble = Double
 
-    eqImp = (==) `on` doubleToWord
+    eqImp _ = (==) `on` doubleToWord
 
     fromRef (TokDouble n) = getDoubleSpecials n
     fromRef TokDoubleNan  = canonicalNaN
-    toRef n
+    toRef _ n
       | isNaN n   = TokDoubleNan
       | otherwise = TokDouble (DoubleSpecials n)
 
-    canonicaliseImp = canonicaliseNaN
+    canonicaliseImp _ = canonicaliseNaN
     canonicaliseRef TokDoubleNan = TokDoubleNan
     canonicaliseRef (TokDouble (DoubleSpecials n))
       | isNaN n   = TokDoubleNan
       | otherwise = TokDouble (DoubleSpecials n)
 
-    encodeImp = encodeDouble
-    decodeImp = decodeDouble
+    encodeImp _ = encodeDouble
+    decodeImp _ = decodeDouble
 
     encodeRef (TokDouble n) = Ref.encodeToken (Ref.MT7_Float64 n)
     encodeRef TokDoubleNan  = Ref.encodeToken (Ref.MT7_Float16 canonicalNaN)
 
-    decodeRef = do tok <- Ref.decodeToken
-                   case tok of
-                     Ref.MT7_Float16 n | isNaN n
-                                       -> return TokDoubleNan
-                     Ref.MT7_Float64 n -> return (TokDouble n)
-                     _                 -> fail "decodeRef (TokDouble)"
+    decodeRef _ = do
+      tok <- Ref.decodeToken
+      case tok of
+        Ref.MT7_Float16 n  | isNaN n
+                          -> return TokDoubleNan
+        Ref.MT7_Float64 n -> return (TokDouble n)
+        _                 -> fail "decodeRef (TokDouble)"
 
 
 --------------------------------------------------------------------------------
@@ -880,13 +917,13 @@ instance Token TokTag where
     type Imp TokTag = Word
 
     fromRef = fromIntegral . Ref.fromUInt . unTokTag
-    toRef   = TokTag . Ref.toUInt . fromIntegral
+    toRef _ = TokTag . Ref.toUInt . fromIntegral
 
-    encodeImp = encodeTag
-    decodeImp = decodeTag
+    encodeImp _ = encodeTag
+    decodeImp _ = decodeTag
 
     encodeRef (TokTag n) = Ref.encodeToken (Ref.MT6_Tag n)
-    decodeRef            = do Ref.MT6_Tag n <- Ref.decodeToken
+    decodeRef _          = do Ref.MT6_Tag n <- Ref.decodeToken
                               return (TokTag n)
 
 
@@ -900,13 +937,13 @@ instance Token TokTag64 where
     type Imp TokTag64 = Word64
 
     fromRef = fromIntegral . Ref.fromUInt . unTokTag64
-    toRef   = TokTag64 . Ref.toUInt . fromIntegral
+    toRef _ = TokTag64 . Ref.toUInt . fromIntegral
 
-    encodeImp = encodeTag64
-    decodeImp = decodeTag64
+    encodeImp _ = encodeTag64
+    decodeImp _ = decodeTag64
 
     encodeRef (TokTag64 n) = Ref.encodeToken (Ref.MT6_Tag n)
-    decodeRef              = do Ref.MT6_Tag n <- Ref.decodeToken
+    decodeRef _            = do Ref.MT6_Tag n <- Ref.decodeToken
                                 return (TokTag64 n)
 
 
@@ -915,13 +952,13 @@ instance Token Ref.Simple where
     type Imp Ref.Simple = Word8
 
     fromRef = Ref.fromSimple
-    toRef   = Ref.toSimple
+    toRef _ = Ref.toSimple
 
-    encodeImp = encodeSimple
-    decodeImp = decodeSimple
+    encodeImp _ = encodeSimple
+    decodeImp _ = decodeSimple
 
     encodeRef n = Ref.encodeToken (Ref.MT7_Simple n)
-    decodeRef   = do Ref.MT7_Simple n <- Ref.decodeToken
+    decodeRef _ = do Ref.MT7_Simple n <- Ref.decodeToken
                      return n
 
 
@@ -932,19 +969,19 @@ instance Token Ref.Simple where
 instance Token Ref.Term where
     type Imp Ref.Term = Term
 
-    eqImp = eqTerm
+    eqImp _ = eqTerm
 
     fromRef = fromRefTerm
-    toRef   = toRefTerm
+    toRef _ = toRefTerm
 
-    canonicaliseImp = canonicaliseTerm
-    canonicaliseRef = Ref.canonicaliseTerm
+    canonicaliseImp _ = canonicaliseTerm
+    canonicaliseRef   = Ref.canonicaliseTerm
 
-    encodeImp = encodeTerm
-    decodeImp = decodeTerm
+    encodeImp _ = encodeTerm
+    decodeImp _ = decodeTerm
 
-    encodeRef = Ref.encodeTerm
-    decodeRef = Ref.decodeTerm
+    encodeRef   = Ref.encodeTerm
+    decodeRef _ = Ref.decodeTerm
 
 
 --------------------------------------------------------------------------------
@@ -954,202 +991,202 @@ testTree :: TestTree
 testTree =
   testGroup "properties"
   [ testGroup "to . id . from = canon_ref"
-    [ testProperty "Word8"   (prop_fromRefToRef @ TokWord8)
-    , testProperty "Word16"  (prop_fromRefToRef @ TokWord16)
-    , testProperty "Word32"  (prop_fromRefToRef @ TokWord32)
-    , testProperty "Word64"  (prop_fromRefToRef @ TokWord64)
-    , testProperty "Word"    (prop_fromRefToRef @ TokWord)
---  , testProperty "NegWord" (prop_fromRefToRef @ TokNegWord)
-    , testProperty "Int8"    (prop_fromRefToRef @ TokInt8)
-    , testProperty "Int16"   (prop_fromRefToRef @ TokInt16)
-    , testProperty "Int32"   (prop_fromRefToRef @ TokInt32)
-    , testProperty "Int64"   (prop_fromRefToRef @ TokInt64)
-    , testProperty "Int"     (prop_fromRefToRef @ TokInt)
-    , testProperty "Integer" (prop_fromRefToRef @ TokInteger)
-    , testProperty "Half"    (prop_fromRefToRef @ TokHalf)
-    , testProperty "Float"   (prop_fromRefToRef @ TokFloat)
-    , testProperty "Double"  (prop_fromRefToRef @ TokDouble)
-    , testProperty "Tag"     (prop_fromRefToRef @ TokTag)
-    , testProperty "Tag64"   (prop_fromRefToRef @ TokTag64)
-    , testProperty "Simple"  (prop_fromRefToRef @ Ref.Simple)
-    , testProperty "Term"    (prop_fromRefToRef @ Ref.Term)
+    [ testProperty "Word8"   (prop_fromRefToRef (Proxy :: Proxy TokWord8))
+    , testProperty "Word16"  (prop_fromRefToRef (Proxy :: Proxy TokWord16))
+    , testProperty "Word32"  (prop_fromRefToRef (Proxy :: Proxy TokWord32))
+    , testProperty "Word64"  (prop_fromRefToRef (Proxy :: Proxy TokWord64))
+    , testProperty "Word"    (prop_fromRefToRef (Proxy :: Proxy TokWord))
+--  , testProperty "NegWord" (prop_fromRefToRef (Proxy :: Proxy TokNegWord))
+    , testProperty "Int8"    (prop_fromRefToRef (Proxy :: Proxy TokInt8))
+    , testProperty "Int16"   (prop_fromRefToRef (Proxy :: Proxy TokInt16))
+    , testProperty "Int32"   (prop_fromRefToRef (Proxy :: Proxy TokInt32))
+    , testProperty "Int64"   (prop_fromRefToRef (Proxy :: Proxy TokInt64))
+    , testProperty "Int"     (prop_fromRefToRef (Proxy :: Proxy TokInt))
+    , testProperty "Integer" (prop_fromRefToRef (Proxy :: Proxy TokInteger))
+    , testProperty "Half"    (prop_fromRefToRef (Proxy :: Proxy TokHalf))
+    , testProperty "Float"   (prop_fromRefToRef (Proxy :: Proxy TokFloat))
+    , testProperty "Double"  (prop_fromRefToRef (Proxy :: Proxy TokDouble))
+    , testProperty "Tag"     (prop_fromRefToRef (Proxy :: Proxy TokTag))
+    , testProperty "Tag64"   (prop_fromRefToRef (Proxy :: Proxy TokTag64))
+    , testProperty "Simple"  (prop_fromRefToRef (Proxy :: Proxy Ref.Simple))
+    , testProperty "Term"    (prop_fromRefToRef (Proxy :: Proxy Ref.Term))
     ]
 
   , testGroup "from . id . to = canon_imp"
-    [ testProperty "Word8"   (prop_toRefFromRef @ TokWord8)
-    , testProperty "Word16"  (prop_toRefFromRef @ TokWord16)
-    , testProperty "Word32"  (prop_toRefFromRef @ TokWord32)
-    , testProperty "Word64"  (prop_toRefFromRef @ TokWord64)
-    , testProperty "Word"    (prop_toRefFromRef @ TokWord)
---  , testProperty "NegWord" (prop_toRefFromRef @ TokNegWord)
-    , testProperty "Int8"    (prop_toRefFromRef @ TokInt8)
-    , testProperty "Int16"   (prop_toRefFromRef @ TokInt16)
-    , testProperty "Int32"   (prop_toRefFromRef @ TokInt32)
-    , testProperty "Int64"   (prop_toRefFromRef @ TokInt64)
-    , testProperty "Int"     (prop_toRefFromRef @ TokInt)
-    , testProperty "Integer" (prop_toRefFromRef @ TokInteger)
-    , testProperty "Half"    (prop_toRefFromRef @ TokHalf)
-    , testProperty "Float"   (prop_toRefFromRef @ TokFloat)
-    , testProperty "Double"  (prop_toRefFromRef @ TokDouble)
-    , testProperty "Tag"     (prop_toRefFromRef @ TokTag)
-    , testProperty "Tag64"   (prop_toRefFromRef @ TokTag64)
-    , testProperty "Simple"  (prop_toRefFromRef @ Ref.Simple)
-    , testProperty "Term"    (prop_toRefFromRef @ Ref.Term)
+    [ testProperty "Word8"   (prop_toRefFromRef (Proxy :: Proxy TokWord8))
+    , testProperty "Word16"  (prop_toRefFromRef (Proxy :: Proxy TokWord16))
+    , testProperty "Word32"  (prop_toRefFromRef (Proxy :: Proxy TokWord32))
+    , testProperty "Word64"  (prop_toRefFromRef (Proxy :: Proxy TokWord64))
+    , testProperty "Word"    (prop_toRefFromRef (Proxy :: Proxy TokWord))
+--  , testProperty "NegWord" (prop_toRefFromRef (Proxy :: Proxy TokNegWord))
+    , testProperty "Int8"    (prop_toRefFromRef (Proxy :: Proxy TokInt8))
+    , testProperty "Int16"   (prop_toRefFromRef (Proxy :: Proxy TokInt16))
+    , testProperty "Int32"   (prop_toRefFromRef (Proxy :: Proxy TokInt32))
+    , testProperty "Int64"   (prop_toRefFromRef (Proxy :: Proxy TokInt64))
+    , testProperty "Int"     (prop_toRefFromRef (Proxy :: Proxy TokInt))
+    , testProperty "Integer" (prop_toRefFromRef (Proxy :: Proxy TokInteger))
+    , testProperty "Half"    (prop_toRefFromRef (Proxy :: Proxy TokHalf))
+    , testProperty "Float"   (prop_toRefFromRef (Proxy :: Proxy TokFloat))
+    , testProperty "Double"  (prop_toRefFromRef (Proxy :: Proxy TokDouble))
+    , testProperty "Tag"     (prop_toRefFromRef (Proxy :: Proxy TokTag))
+    , testProperty "Tag64"   (prop_toRefFromRef (Proxy :: Proxy TokTag64))
+    , testProperty "Simple"  (prop_toRefFromRef (Proxy :: Proxy Ref.Simple))
+    , testProperty "Term"    (prop_toRefFromRef (Proxy :: Proxy Ref.Term))
     ]
 
   , testGroup "dec_ref . enc_ref = id"
-    [ testProperty "Word8"   (prop_encodeRefdecodeRef @ TokWord8)
-    , testProperty "Word16"  (prop_encodeRefdecodeRef @ TokWord16)
-    , testProperty "Word32"  (prop_encodeRefdecodeRef @ TokWord32)
-    , testProperty "Word64"  (prop_encodeRefdecodeRef @ TokWord64)
-    , testProperty "Word"    (prop_encodeRefdecodeRef @ TokWord)
---  , testProperty "NegWord" (prop_encodeRefdecodeRef @ TokNegWord)
-    , testProperty "Int8"    (prop_encodeRefdecodeRef @ TokInt8)
-    , testProperty "Int16"   (prop_encodeRefdecodeRef @ TokInt16)
-    , testProperty "Int32"   (prop_encodeRefdecodeRef @ TokInt32)
-    , testProperty "Int64"   (prop_encodeRefdecodeRef @ TokInt64)
-    , testProperty "Int"     (prop_encodeRefdecodeRef @ TokInt)
-    , testProperty "Integer" (prop_encodeRefdecodeRef @ TokInteger)
-    , testProperty "Half"    (prop_encodeRefdecodeRef @ TokHalf)
-    , testProperty "Float"   (prop_encodeRefdecodeRef @ TokFloat)
-    , testProperty "Double"  (prop_encodeRefdecodeRef @ TokDouble)
-    , testProperty "Tag"     (prop_encodeRefdecodeRef @ TokTag)
-    , testProperty "Tag64"   (prop_encodeRefdecodeRef @ TokTag64)
-    , testProperty "Simple"  (prop_encodeRefdecodeRef @ Ref.Simple)
-    , testProperty "Term"    (prop_encodeRefdecodeRef @ Ref.Term)
+    [ testProperty "Word8"   (prop_encodeRefdecodeRef (Proxy :: Proxy TokWord8))
+    , testProperty "Word16"  (prop_encodeRefdecodeRef (Proxy :: Proxy TokWord16))
+    , testProperty "Word32"  (prop_encodeRefdecodeRef (Proxy :: Proxy TokWord32))
+    , testProperty "Word64"  (prop_encodeRefdecodeRef (Proxy :: Proxy TokWord64))
+    , testProperty "Word"    (prop_encodeRefdecodeRef (Proxy :: Proxy TokWord))
+--  , testProperty "NegWord" (prop_encodeRefdecodeRef (Proxy :: Proxy TokNegWord))
+    , testProperty "Int8"    (prop_encodeRefdecodeRef (Proxy :: Proxy TokInt8))
+    , testProperty "Int16"   (prop_encodeRefdecodeRef (Proxy :: Proxy TokInt16))
+    , testProperty "Int32"   (prop_encodeRefdecodeRef (Proxy :: Proxy TokInt32))
+    , testProperty "Int64"   (prop_encodeRefdecodeRef (Proxy :: Proxy TokInt64))
+    , testProperty "Int"     (prop_encodeRefdecodeRef (Proxy :: Proxy TokInt))
+    , testProperty "Integer" (prop_encodeRefdecodeRef (Proxy :: Proxy TokInteger))
+    , testProperty "Half"    (prop_encodeRefdecodeRef (Proxy :: Proxy TokHalf))
+    , testProperty "Float"   (prop_encodeRefdecodeRef (Proxy :: Proxy TokFloat))
+    , testProperty "Double"  (prop_encodeRefdecodeRef (Proxy :: Proxy TokDouble))
+    , testProperty "Tag"     (prop_encodeRefdecodeRef (Proxy :: Proxy TokTag))
+    , testProperty "Tag64"   (prop_encodeRefdecodeRef (Proxy :: Proxy TokTag64))
+    , testProperty "Simple"  (prop_encodeRefdecodeRef (Proxy :: Proxy Ref.Simple))
+    , testProperty "Term"    (prop_encodeRefdecodeRef (Proxy :: Proxy Ref.Term))
     ]
 
   , testGroup "dec_imp . enc_imp = canon_imp"
-    [ testProperty "Word8"   (prop_encodeImpdecodeImp @ TokWord8)
-    , testProperty "Word16"  (prop_encodeImpdecodeImp @ TokWord16)
-    , testProperty "Word32"  (prop_encodeImpdecodeImp @ TokWord32)
-    , testProperty "Word64"  (prop_encodeImpdecodeImp @ TokWord64)
-    , testProperty "Word"    (prop_encodeImpdecodeImp @ TokWord)
---  , testProperty "NegWord" (prop_encodeImpdecodeImp @ TokNegWord)
-    , testProperty "Int8"    (prop_encodeImpdecodeImp @ TokInt8)
-    , testProperty "Int16"   (prop_encodeImpdecodeImp @ TokInt16)
-    , testProperty "Int32"   (prop_encodeImpdecodeImp @ TokInt32)
-    , testProperty "Int64"   (prop_encodeImpdecodeImp @ TokInt64)
-    , testProperty "Int"     (prop_encodeImpdecodeImp @ TokInt)
-    , testProperty "Integer" (prop_encodeImpdecodeImp @ TokInteger)
-    , testProperty "Half"    (prop_encodeImpdecodeImp @ TokHalf)
-    , testProperty "Float"   (prop_encodeImpdecodeImp @ TokFloat)
-    , testProperty "Double"  (prop_encodeImpdecodeImp @ TokDouble)
-    , testProperty "Tag"     (prop_encodeImpdecodeImp @ TokTag)
-    , testProperty "Tag64"   (prop_encodeImpdecodeImp @ TokTag64)
-    , testProperty "Simple"  (prop_encodeImpdecodeImp @ Ref.Simple)
-    , testProperty "Term"    (prop_encodeImpdecodeImp @ Ref.Term)
+    [ testProperty "Word8"   (prop_encodeImpdecodeImp (Proxy :: Proxy TokWord8))
+    , testProperty "Word16"  (prop_encodeImpdecodeImp (Proxy :: Proxy TokWord16))
+    , testProperty "Word32"  (prop_encodeImpdecodeImp (Proxy :: Proxy TokWord32))
+    , testProperty "Word64"  (prop_encodeImpdecodeImp (Proxy :: Proxy TokWord64))
+    , testProperty "Word"    (prop_encodeImpdecodeImp (Proxy :: Proxy TokWord))
+--  , testProperty "NegWord" (prop_encodeImpdecodeImp (Proxy :: Proxy TokNegWord))
+    , testProperty "Int8"    (prop_encodeImpdecodeImp (Proxy :: Proxy TokInt8))
+    , testProperty "Int16"   (prop_encodeImpdecodeImp (Proxy :: Proxy TokInt16))
+    , testProperty "Int32"   (prop_encodeImpdecodeImp (Proxy :: Proxy TokInt32))
+    , testProperty "Int64"   (prop_encodeImpdecodeImp (Proxy :: Proxy TokInt64))
+    , testProperty "Int"     (prop_encodeImpdecodeImp (Proxy :: Proxy TokInt))
+    , testProperty "Integer" (prop_encodeImpdecodeImp (Proxy :: Proxy TokInteger))
+    , testProperty "Half"    (prop_encodeImpdecodeImp (Proxy :: Proxy TokHalf))
+    , testProperty "Float"   (prop_encodeImpdecodeImp (Proxy :: Proxy TokFloat))
+    , testProperty "Double"  (prop_encodeImpdecodeImp (Proxy :: Proxy TokDouble))
+    , testProperty "Tag"     (prop_encodeImpdecodeImp (Proxy :: Proxy TokTag))
+    , testProperty "Tag64"   (prop_encodeImpdecodeImp (Proxy :: Proxy TokTag64))
+    , testProperty "Simple"  (prop_encodeImpdecodeImp (Proxy :: Proxy Ref.Simple))
+    , testProperty "Term"    (prop_encodeImpdecodeImp (Proxy :: Proxy Ref.Term))
     ]
 
   , testGroup "dec_imp . enc_imp = canon_imp (all 2-splits)"
-    [ testProperty "Word8"   (prop_encodeImpdecodeImp_splits2 @ TokWord8)
-    , testProperty "Word16"  (prop_encodeImpdecodeImp_splits2 @ TokWord16)
-    , testProperty "Word32"  (prop_encodeImpdecodeImp_splits2 @ TokWord32)
-    , testProperty "Word64"  (prop_encodeImpdecodeImp_splits2 @ TokWord64)
-    , testProperty "Word"    (prop_encodeImpdecodeImp_splits2 @ TokWord)
---  , testProperty "NegWord" (prop_encodeImpdecodeImp_splits2 @ TokNegWord)
-    , testProperty "Int8"    (prop_encodeImpdecodeImp_splits2 @ TokInt8)
-    , testProperty "Int16"   (prop_encodeImpdecodeImp_splits2 @ TokInt16)
-    , testProperty "Int32"   (prop_encodeImpdecodeImp_splits2 @ TokInt32)
-    , testProperty "Int64"   (prop_encodeImpdecodeImp_splits2 @ TokInt64)
-    , testProperty "Int"     (prop_encodeImpdecodeImp_splits2 @ TokInt)
-    , testProperty "Integer" (prop_encodeImpdecodeImp_splits2 @ TokInteger)
-    , testProperty "Half"    (prop_encodeImpdecodeImp_splits2 @ TokHalf)
-    , testProperty "Float"   (prop_encodeImpdecodeImp_splits2 @ TokFloat)
-    , testProperty "Double"  (prop_encodeImpdecodeImp_splits2 @ TokDouble)
-    , testProperty "Tag"     (prop_encodeImpdecodeImp_splits2 @ TokTag)
-    , testProperty "Tag64"   (prop_encodeImpdecodeImp_splits2 @ TokTag64)
-    , testProperty "Simple"  (prop_encodeImpdecodeImp_splits2 @ Ref.Simple)
+    [ testProperty "Word8"   (prop_encodeImpdecodeImp_splits2 (Proxy :: Proxy TokWord8))
+    , testProperty "Word16"  (prop_encodeImpdecodeImp_splits2 (Proxy :: Proxy TokWord16))
+    , testProperty "Word32"  (prop_encodeImpdecodeImp_splits2 (Proxy :: Proxy TokWord32))
+    , testProperty "Word64"  (prop_encodeImpdecodeImp_splits2 (Proxy :: Proxy TokWord64))
+    , testProperty "Word"    (prop_encodeImpdecodeImp_splits2 (Proxy :: Proxy TokWord))
+--  , testProperty "NegWord" (prop_encodeImpdecodeImp_splits2 (Proxy :: Proxy TokNegWord))
+    , testProperty "Int8"    (prop_encodeImpdecodeImp_splits2 (Proxy :: Proxy TokInt8))
+    , testProperty "Int16"   (prop_encodeImpdecodeImp_splits2 (Proxy :: Proxy TokInt16))
+    , testProperty "Int32"   (prop_encodeImpdecodeImp_splits2 (Proxy :: Proxy TokInt32))
+    , testProperty "Int64"   (prop_encodeImpdecodeImp_splits2 (Proxy :: Proxy TokInt64))
+    , testProperty "Int"     (prop_encodeImpdecodeImp_splits2 (Proxy :: Proxy TokInt))
+    , testProperty "Integer" (prop_encodeImpdecodeImp_splits2 (Proxy :: Proxy TokInteger))
+    , testProperty "Half"    (prop_encodeImpdecodeImp_splits2 (Proxy :: Proxy TokHalf))
+    , testProperty "Float"   (prop_encodeImpdecodeImp_splits2 (Proxy :: Proxy TokFloat))
+    , testProperty "Double"  (prop_encodeImpdecodeImp_splits2 (Proxy :: Proxy TokDouble))
+    , testProperty "Tag"     (prop_encodeImpdecodeImp_splits2 (Proxy :: Proxy TokTag))
+    , testProperty "Tag64"   (prop_encodeImpdecodeImp_splits2 (Proxy :: Proxy TokTag64))
+    , testProperty "Simple"  (prop_encodeImpdecodeImp_splits2 (Proxy :: Proxy Ref.Simple))
     , localOption (QuickCheckMaxSize 100) $
-      testProperty "Term"    (prop_encodeImpdecodeImp_splits2 @ Ref.Term)
+      testProperty "Term"    (prop_encodeImpdecodeImp_splits2 (Proxy :: Proxy Ref.Term))
     ]
 
   , testGroup "dec_imp . enc_imp = canon_imp (all 3-splits)"
-    [ testProperty "Word8"   (prop_encodeImpdecodeImp_splits3 @ TokWord8)
-    , testProperty "Word16"  (prop_encodeImpdecodeImp_splits3 @ TokWord16)
-    , testProperty "Word32"  (prop_encodeImpdecodeImp_splits3 @ TokWord32)
-    , testProperty "Word64"  (prop_encodeImpdecodeImp_splits3 @ TokWord64)
-    , testProperty "Word"    (prop_encodeImpdecodeImp_splits3 @ TokWord)
---  , testProperty "NegWord" (prop_encodeImpdecodeImp_splits3 @ TokNegWord)
-    , testProperty "Int8"    (prop_encodeImpdecodeImp_splits3 @ TokInt8)
-    , testProperty "Int16"   (prop_encodeImpdecodeImp_splits3 @ TokInt16)
-    , testProperty "Int32"   (prop_encodeImpdecodeImp_splits3 @ TokInt32)
-    , testProperty "Int64"   (prop_encodeImpdecodeImp_splits3 @ TokInt64)
-    , testProperty "Int"     (prop_encodeImpdecodeImp_splits3 @ TokInt)
-    , testProperty "Integer" (prop_encodeImpdecodeImp_splits3 @ TokInteger)
-    , testProperty "Half"    (prop_encodeImpdecodeImp_splits3 @ TokHalf)
-    , testProperty "Float"   (prop_encodeImpdecodeImp_splits3 @ TokFloat)
-    , testProperty "Double"  (prop_encodeImpdecodeImp_splits3 @ TokDouble)
-    , testProperty "Tag"     (prop_encodeImpdecodeImp_splits3 @ TokTag)
-    , testProperty "Tag64"   (prop_encodeImpdecodeImp_splits3 @ TokTag64)
-    , testProperty "Simple"  (prop_encodeImpdecodeImp_splits3 @ Ref.Simple)
+    [ testProperty "Word8"   (prop_encodeImpdecodeImp_splits3 (Proxy :: Proxy TokWord8))
+    , testProperty "Word16"  (prop_encodeImpdecodeImp_splits3 (Proxy :: Proxy TokWord16))
+    , testProperty "Word32"  (prop_encodeImpdecodeImp_splits3 (Proxy :: Proxy TokWord32))
+    , testProperty "Word64"  (prop_encodeImpdecodeImp_splits3 (Proxy :: Proxy TokWord64))
+    , testProperty "Word"    (prop_encodeImpdecodeImp_splits3 (Proxy :: Proxy TokWord))
+--  , testProperty "NegWord" (prop_encodeImpdecodeImp_splits3 (Proxy :: Proxy TokNegWord))
+    , testProperty "Int8"    (prop_encodeImpdecodeImp_splits3 (Proxy :: Proxy TokInt8))
+    , testProperty "Int16"   (prop_encodeImpdecodeImp_splits3 (Proxy :: Proxy TokInt16))
+    , testProperty "Int32"   (prop_encodeImpdecodeImp_splits3 (Proxy :: Proxy TokInt32))
+    , testProperty "Int64"   (prop_encodeImpdecodeImp_splits3 (Proxy :: Proxy TokInt64))
+    , testProperty "Int"     (prop_encodeImpdecodeImp_splits3 (Proxy :: Proxy TokInt))
+    , testProperty "Integer" (prop_encodeImpdecodeImp_splits3 (Proxy :: Proxy TokInteger))
+    , testProperty "Half"    (prop_encodeImpdecodeImp_splits3 (Proxy :: Proxy TokHalf))
+    , testProperty "Float"   (prop_encodeImpdecodeImp_splits3 (Proxy :: Proxy TokFloat))
+    , testProperty "Double"  (prop_encodeImpdecodeImp_splits3 (Proxy :: Proxy TokDouble))
+    , testProperty "Tag"     (prop_encodeImpdecodeImp_splits3 (Proxy :: Proxy TokTag))
+    , testProperty "Tag64"   (prop_encodeImpdecodeImp_splits3 (Proxy :: Proxy TokTag64))
+    , testProperty "Simple"  (prop_encodeImpdecodeImp_splits3 (Proxy :: Proxy Ref.Simple))
     , localOption (QuickCheckMaxSize 25) $
-      testProperty "Term"    (prop_encodeImpdecodeImp_splits3 @ Ref.Term)
+      testProperty "Term"    (prop_encodeImpdecodeImp_splits3 (Proxy :: Proxy Ref.Term))
     ]
 
   , testGroup "enc_imp . from = enc_ref . canon_ref"
-    [ testProperty "Word8"   (prop_encodeRefencodeImp1 @ TokWord8)
-    , testProperty "Word16"  (prop_encodeRefencodeImp1 @ TokWord16)
-    , testProperty "Word32"  (prop_encodeRefencodeImp1 @ TokWord32)
-    , testProperty "Word64"  (prop_encodeRefencodeImp1 @ TokWord64)
-    , testProperty "Word"    (prop_encodeRefencodeImp1 @ TokWord)
---  , testProperty "NegWord" (prop_encodeRefencodeImp1 @ TokNegWord)
-    , testProperty "Int8"    (prop_encodeRefencodeImp1 @ TokInt8)
-    , testProperty "Int16"   (prop_encodeRefencodeImp1 @ TokInt16)
-    , testProperty "Int32"   (prop_encodeRefencodeImp1 @ TokInt32)
-    , testProperty "Int64"   (prop_encodeRefencodeImp1 @ TokInt64)
-    , testProperty "Int"     (prop_encodeRefencodeImp1 @ TokInt)
-    , testProperty "Integer" (prop_encodeRefencodeImp1 @ TokInteger)
-    , testProperty "Half"    (prop_encodeRefencodeImp1 @ TokHalf)
-    , testProperty "Float"   (prop_encodeRefencodeImp1 @ TokFloat)
-    , testProperty "Double"  (prop_encodeRefencodeImp1 @ TokDouble)
-    , testProperty "Tag"     (prop_encodeRefencodeImp1 @ TokTag)
-    , testProperty "Tag64"   (prop_encodeRefencodeImp1 @ TokTag64)
-    , testProperty "Simple"  (prop_encodeRefencodeImp1 @ Ref.Simple)
-    , testProperty "Term"    (prop_encodeRefencodeImp1 @ Ref.Term)
+    [ testProperty "Word8"   (prop_encodeRefencodeImp1 (Proxy :: Proxy TokWord8))
+    , testProperty "Word16"  (prop_encodeRefencodeImp1 (Proxy :: Proxy TokWord16))
+    , testProperty "Word32"  (prop_encodeRefencodeImp1 (Proxy :: Proxy TokWord32))
+    , testProperty "Word64"  (prop_encodeRefencodeImp1 (Proxy :: Proxy TokWord64))
+    , testProperty "Word"    (prop_encodeRefencodeImp1 (Proxy :: Proxy TokWord))
+--  , testProperty "NegWord" (prop_encodeRefencodeImp1 (Proxy :: Proxy TokNegWord))
+    , testProperty "Int8"    (prop_encodeRefencodeImp1 (Proxy :: Proxy TokInt8))
+    , testProperty "Int16"   (prop_encodeRefencodeImp1 (Proxy :: Proxy TokInt16))
+    , testProperty "Int32"   (prop_encodeRefencodeImp1 (Proxy :: Proxy TokInt32))
+    , testProperty "Int64"   (prop_encodeRefencodeImp1 (Proxy :: Proxy TokInt64))
+    , testProperty "Int"     (prop_encodeRefencodeImp1 (Proxy :: Proxy TokInt))
+    , testProperty "Integer" (prop_encodeRefencodeImp1 (Proxy :: Proxy TokInteger))
+    , testProperty "Half"    (prop_encodeRefencodeImp1 (Proxy :: Proxy TokHalf))
+    , testProperty "Float"   (prop_encodeRefencodeImp1 (Proxy :: Proxy TokFloat))
+    , testProperty "Double"  (prop_encodeRefencodeImp1 (Proxy :: Proxy TokDouble))
+    , testProperty "Tag"     (prop_encodeRefencodeImp1 (Proxy :: Proxy TokTag))
+    , testProperty "Tag64"   (prop_encodeRefencodeImp1 (Proxy :: Proxy TokTag64))
+    , testProperty "Simple"  (prop_encodeRefencodeImp1 (Proxy :: Proxy Ref.Simple))
+    , testProperty "Term"    (prop_encodeRefencodeImp1 (Proxy :: Proxy Ref.Term))
     ]
 
   , testGroup "enc_ref . to = enc_imp"
-    [ testProperty "Word8"   (prop_encodeRefencodeImp2 @ TokWord8)
-    , testProperty "Word16"  (prop_encodeRefencodeImp2 @ TokWord16)
-    , testProperty "Word32"  (prop_encodeRefencodeImp2 @ TokWord32)
-    , testProperty "Word64"  (prop_encodeRefencodeImp2 @ TokWord64)
-    , testProperty "Word"    (prop_encodeRefencodeImp2 @ TokWord)
---  , testProperty "NegWord" (prop_encodeRefencodeImp2 @ TokNegWord)
-    , testProperty "Int8"    (prop_encodeRefencodeImp2 @ TokInt8)
-    , testProperty "Int16"   (prop_encodeRefencodeImp2 @ TokInt16)
-    , testProperty "Int32"   (prop_encodeRefencodeImp2 @ TokInt32)
-    , testProperty "Int64"   (prop_encodeRefencodeImp2 @ TokInt64)
-    , testProperty "Int"     (prop_encodeRefencodeImp2 @ TokInt)
-    , testProperty "Integer" (prop_encodeRefencodeImp2 @ TokInteger)
-    , testProperty "Half"    (prop_encodeRefencodeImp2 @ TokHalf)
-    , testProperty "Float"   (prop_encodeRefencodeImp2 @ TokFloat)
-    , testProperty "Double"  (prop_encodeRefencodeImp2 @ TokDouble)
-    , testProperty "Tag"     (prop_encodeRefencodeImp2 @ TokTag)
-    , testProperty "Tag64"   (prop_encodeRefencodeImp2 @ TokTag64)
-    , testProperty "Simple"  (prop_encodeRefencodeImp2 @ Ref.Simple)
-    , testProperty "Term"    (prop_encodeRefencodeImp2 @ Ref.Term)
+    [ testProperty "Word8"   (prop_encodeRefencodeImp2 (Proxy :: Proxy TokWord8))
+    , testProperty "Word16"  (prop_encodeRefencodeImp2 (Proxy :: Proxy TokWord16))
+    , testProperty "Word32"  (prop_encodeRefencodeImp2 (Proxy :: Proxy TokWord32))
+    , testProperty "Word64"  (prop_encodeRefencodeImp2 (Proxy :: Proxy TokWord64))
+    , testProperty "Word"    (prop_encodeRefencodeImp2 (Proxy :: Proxy TokWord))
+--  , testProperty "NegWord" (prop_encodeRefencodeImp2 (Proxy :: Proxy TokNegWord))
+    , testProperty "Int8"    (prop_encodeRefencodeImp2 (Proxy :: Proxy TokInt8))
+    , testProperty "Int16"   (prop_encodeRefencodeImp2 (Proxy :: Proxy TokInt16))
+    , testProperty "Int32"   (prop_encodeRefencodeImp2 (Proxy :: Proxy TokInt32))
+    , testProperty "Int64"   (prop_encodeRefencodeImp2 (Proxy :: Proxy TokInt64))
+    , testProperty "Int"     (prop_encodeRefencodeImp2 (Proxy :: Proxy TokInt))
+    , testProperty "Integer" (prop_encodeRefencodeImp2 (Proxy :: Proxy TokInteger))
+    , testProperty "Half"    (prop_encodeRefencodeImp2 (Proxy :: Proxy TokHalf))
+    , testProperty "Float"   (prop_encodeRefencodeImp2 (Proxy :: Proxy TokFloat))
+    , testProperty "Double"  (prop_encodeRefencodeImp2 (Proxy :: Proxy TokDouble))
+    , testProperty "Tag"     (prop_encodeRefencodeImp2 (Proxy :: Proxy TokTag))
+    , testProperty "Tag64"   (prop_encodeRefencodeImp2 (Proxy :: Proxy TokTag64))
+    , testProperty "Simple"  (prop_encodeRefencodeImp2 (Proxy :: Proxy Ref.Simple))
+    , testProperty "Term"    (prop_encodeRefencodeImp2 (Proxy :: Proxy Ref.Term))
     ]
 
   , testGroup "dec_imp . enc_ref = from . dec_ref . enc_ref"
-    [ testProperty "Word8"   (prop_decodeRefdecodeImp @ TokWord8)
-    , testProperty "Word16"  (prop_decodeRefdecodeImp @ TokWord16)
-    , testProperty "Word32"  (prop_decodeRefdecodeImp @ TokWord32)
-    , testProperty "Word64"  (prop_decodeRefdecodeImp @ TokWord64)
-    , testProperty "Word"    (prop_decodeRefdecodeImp @ TokWord)
---  , testProperty "NegWord" (prop_decodeRefdecodeImp @ TokNegWord)
-    , testProperty "Int8"    (prop_decodeRefdecodeImp @ TokInt8)
-    , testProperty "Int16"   (prop_decodeRefdecodeImp @ TokInt16)
-    , testProperty "Int32"   (prop_decodeRefdecodeImp @ TokInt32)
-    , testProperty "Int64"   (prop_decodeRefdecodeImp @ TokInt64)
-    , testProperty "Int"     (prop_decodeRefdecodeImp @ TokInt)
-    , testProperty "Integer" (prop_decodeRefdecodeImp @ TokInteger)
-    , testProperty "Half"    (prop_decodeRefdecodeImp @ TokHalf)
-    , testProperty "Float"   (prop_decodeRefdecodeImp @ TokFloat)
-    , testProperty "Double"  (prop_decodeRefdecodeImp @ TokDouble)
-    , testProperty "Tag"     (prop_decodeRefdecodeImp @ TokTag)
-    , testProperty "Tag64"   (prop_decodeRefdecodeImp @ TokTag64)
-    , testProperty "Simple"  (prop_decodeRefdecodeImp @ Ref.Simple)
-    , testProperty "Term"    (prop_decodeRefdecodeImp @ Ref.Term)
+    [ testProperty "Word8"   (prop_decodeRefdecodeImp (Proxy :: Proxy TokWord8))
+    , testProperty "Word16"  (prop_decodeRefdecodeImp (Proxy :: Proxy TokWord16))
+    , testProperty "Word32"  (prop_decodeRefdecodeImp (Proxy :: Proxy TokWord32))
+    , testProperty "Word64"  (prop_decodeRefdecodeImp (Proxy :: Proxy TokWord64))
+    , testProperty "Word"    (prop_decodeRefdecodeImp (Proxy :: Proxy TokWord))
+--  , testProperty "NegWord" (prop_decodeRefdecodeImp (Proxy :: Proxy TokNegWord))
+    , testProperty "Int8"    (prop_decodeRefdecodeImp (Proxy :: Proxy TokInt8))
+    , testProperty "Int16"   (prop_decodeRefdecodeImp (Proxy :: Proxy TokInt16))
+    , testProperty "Int32"   (prop_decodeRefdecodeImp (Proxy :: Proxy TokInt32))
+    , testProperty "Int64"   (prop_decodeRefdecodeImp (Proxy :: Proxy TokInt64))
+    , testProperty "Int"     (prop_decodeRefdecodeImp (Proxy :: Proxy TokInt))
+    , testProperty "Integer" (prop_decodeRefdecodeImp (Proxy :: Proxy TokInteger))
+    , testProperty "Half"    (prop_decodeRefdecodeImp (Proxy :: Proxy TokHalf))
+    , testProperty "Float"   (prop_decodeRefdecodeImp (Proxy :: Proxy TokFloat))
+    , testProperty "Double"  (prop_decodeRefdecodeImp (Proxy :: Proxy TokDouble))
+    , testProperty "Tag"     (prop_decodeRefdecodeImp (Proxy :: Proxy TokTag))
+    , testProperty "Tag64"   (prop_decodeRefdecodeImp (Proxy :: Proxy TokTag64))
+    , testProperty "Simple"  (prop_decodeRefdecodeImp (Proxy :: Proxy Ref.Simple))
+    , testProperty "Term"    (prop_decodeRefdecodeImp (Proxy :: Proxy Ref.Term))
     ]
   ]

--- a/cborg/tests/Tests/Reference.hs
+++ b/cborg/tests/Tests/Reference.hs
@@ -20,6 +20,8 @@ import           Data.Word
 import qualified Numeric.Half as Half
 
 import           Tests.Reference.Implementation as CBOR
+import           Tests.Reference.Generators
+                   ( HalfSpecials(..), FloatSpecials(..), DoubleSpecials(..) )
 import           Tests.Reference.TestVectors
 
 
@@ -87,9 +89,9 @@ termToJson  TFalse        = Aeson.Bool False
 termToJson  TNull         = Aeson.Null
 termToJson  TUndef        = Aeson.Null -- replacement value
 termToJson (TSimple _)    = Aeson.Null -- replacement value
-termToJson (TFloat16 f)   = Aeson.Number (fromFloatDigits (Half.fromHalf f))
-termToJson (TFloat32 f)   = Aeson.Number (fromFloatDigits f)
-termToJson (TFloat64 f)   = Aeson.Number (fromFloatDigits f)
+termToJson (TFloat16 f)   = Aeson.Number (fromFloatDigits (Half.fromHalf (getHalfSpecials f)))
+termToJson (TFloat32 f)   = Aeson.Number (fromFloatDigits (getFloatSpecials f))
+termToJson (TFloat64 f)   = Aeson.Number (fromFloatDigits (getDoubleSpecials f))
 
 bytesToBase64Text :: [Word8] -> T.Text
 bytesToBase64Text = T.decodeLatin1 . Base64url.encode . BS.pack

--- a/cborg/tests/Tests/Reference/Generators.hs
+++ b/cborg/tests/Tests/Reference/Generators.hs
@@ -1,10 +1,18 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Tests.Reference.Generators (
     -- * Integer with a large range
     LargeInteger(..)
 
     -- * Floats with special values
+  , HalfSpecials(..)
   , FloatSpecials(..)
+  , DoubleSpecials(..)
 
     -- * Floating types to bit representation conversion
   , halfToWord
@@ -16,10 +24,13 @@ module Tests.Reference.Generators (
   ) where
 
 import           Data.Word
+import           Numeric (showHex)
 import           Numeric.Half as Half
+import           Data.Proxy
 
 import           Foreign
 import           System.IO.Unsafe
+import           System.Random (Random)
 
 import           Test.QuickCheck
 
@@ -83,16 +94,143 @@ fromFloat float =
 --
 
 instance Arbitrary Half where
-  arbitrary = Half.Half . fromIntegral <$> (arbitrary :: Gen Word16)
+  arbitrary = getHalfSpecials <$> arbitrary
+  shrink    = shrinkRealFrac
 
-newtype FloatSpecials n = FloatSpecials { getFloatSpecials :: n }
-  deriving (Show, Eq)
+newtype HalfSpecials   = HalfSpecials   { getHalfSpecials   :: Half }
+  deriving (Num, Fractional)
 
-instance (Arbitrary n, RealFloat n) => Arbitrary (FloatSpecials n) where
-  arbitrary =
+newtype FloatSpecials  = FloatSpecials  { getFloatSpecials  :: Float }
+  deriving (Num, Fractional)
+
+newtype DoubleSpecials = DoubleSpecials { getDoubleSpecials :: Double }
+  deriving (Num, Fractional)
+
+instance Eq HalfSpecials where
+  HalfSpecials a == HalfSpecials b = halfToWord a == halfToWord b
+
+instance Eq FloatSpecials where
+  FloatSpecials a == FloatSpecials b = floatToWord a == floatToWord b
+
+instance Eq DoubleSpecials where
+  DoubleSpecials a == DoubleSpecials b = doubleToWord a == doubleToWord b
+
+instance Show HalfSpecials where
+  showsPrec p (HalfSpecials n)
+    | isNaN n   = showString "NaN{-0x" . showHex (halfToWord n) . showString "-}"
+    | otherwise = showsPrec p n
+
+instance Show FloatSpecials where
+  showsPrec p (FloatSpecials n)
+    | isNaN n   = showString "NaN{-0x" . showHex (floatToWord n) . showString "-}"
+    | otherwise = showsPrec p n
+
+instance Show DoubleSpecials where
+  showsPrec p (DoubleSpecials n)
+    | isNaN n   = showString "NaN{-0x" . showHex (doubleToWord n) . showString "-}"
+    | otherwise = showsPrec p n
+
+instance Arbitrary HalfSpecials where
+  arbitrary = HalfSpecials <$> frequency [ (2, arbitraryFloating)
+                                         , (1, arbitraryFloatSpecials) ]
+  shrink (HalfSpecials n) = [ HalfSpecials n' | n' <- shrinkRealFrac n ]
+
+instance Arbitrary FloatSpecials where
+  arbitrary = FloatSpecials <$> frequency [ (2, arbitraryFloating)
+                                          , (1, arbitraryFloatSpecials) ]
+  shrink (FloatSpecials n) = [ FloatSpecials n' | n' <- shrinkRealFrac n ]
+
+instance Arbitrary DoubleSpecials where
+  arbitrary = DoubleSpecials <$> frequency [ (2, arbitraryFloating)
+                                           , (1, arbitraryFloatSpecials) ]
+  shrink (DoubleSpecials n) = [ DoubleSpecials n' | n' <- shrinkRealFrac n ]
+
+
+-- | Generate a float from a uniformly random bit pattern
+--
+arbitraryFloating :: forall n. RealFloatIEEE n => Gen n
+arbitraryFloating = wordToFloating <$> arbitraryBoundedIntegral
+
+-- | Generate float special values, see 'IeeeSpecials',
+--
+-- In particular we generate more than a single NaN bit pattern so that we can
+-- test non-canonical representations. The other special values have a single
+-- bit pattern.
+--
+arbitraryFloatSpecials :: forall n. (RealFloatIEEE n, Random (FloatWord n))
+                       => Gen n
+arbitraryFloatSpecials =
     frequency
-      [ (7, FloatSpecials <$> arbitrary)
-      , (1, pure (FloatSpecials (1/0)) )  -- +Infinity
-      , (1, pure (FloatSpecials (0/0)) )  --  NaN
-      , (1, pure (FloatSpecials (-1/0)) ) -- -Infinity
+      [ (1, pure (wordToFloating positiveInfinity))
+      , (1, pure (wordToFloating negativeInfinity))
+      , (1, pure (wordToFloating negativeZero))
+      , (3, wordToFloating <$> choose nanRange)
       ]
+  where
+    IeeeSpecials {..} = floatIeeeSpecials (Proxy :: Proxy n)
+
+-- | Special values for IEEE float types, including negative 0,
+-- positive and negative infinity and a range of NaN values.
+--
+data IeeeSpecials n = IeeeSpecials {
+       positiveInfinity :: n,
+       negativeInfinity :: n,
+       negativeZero     :: n,
+       nanRange         :: (n, n)
+     }
+  deriving (Eq, Functor, Show)
+
+-- | The 'IeeeSpecials' values for 'RealFloatIEEE' types (i.e. 'Half', 'Float'
+-- and 'Double').
+--
+-- To make sense of the bit-twiddling here, see
+--
+-- <https://en.wikipedia.org/wiki/Single-precision_floating-point_format>
+-- <https://en.wikipedia.org/wiki/Half-precision_floating-point_format>
+-- <https://en.wikipedia.org/wiki/Double-precision_floating-point_format>
+--
+floatIeeeSpecials :: RealFloatIEEE n => Proxy n -> IeeeSpecials (FloatWord n)
+floatIeeeSpecials p =
+    IeeeSpecials {..}
+  where
+    positiveInfinity = (setBit 0 (exponentBits p)    - 1)
+                       `shiftL` significandBits p
+    negativeInfinity = (setBit 0 (exponentBits p +1) - 1)
+                       `shiftL` significandBits p
+    negativeZero     =  setBit 0 (exponentBits p + significandBits p)
+    nanRange         = (positiveInfinity, negativeZero - 1)
+
+class (RealFloat n, Integral (FloatWord n), Show (FloatWord n),
+       Bounded (FloatWord n), Bits (FloatWord n))
+   => RealFloatIEEE n where
+  exponentBits    :: Proxy n -> Int
+  significandBits :: Proxy n -> Int
+
+  type FloatWord n :: *
+  wordToFloating  :: FloatWord n -> n
+--floatingToWord  :: n -> FloatWord n
+
+instance RealFloatIEEE Half where
+  exponentBits    _ = 5
+  significandBits _ = 10
+
+  type FloatWord Half = Word16
+  wordToFloating      = wordToHalf
+--floatingToWord      = halfToWord
+
+instance RealFloatIEEE Float where
+  exponentBits    _ = 8
+  significandBits _ = 23
+
+  type FloatWord Float = Word32
+  wordToFloating       = wordToFloat
+--floatingToWord       = floatToWord
+
+instance RealFloatIEEE Double where
+  exponentBits    _ = 11
+  significandBits _ = 52
+
+  type FloatWord Double = Word64
+  wordToFloating        = wordToDouble
+--floatingToWord        = doubleToWord
+

--- a/cborg/tests/Tests/Reference/Generators.hs
+++ b/cborg/tests/Tests/Reference/Generators.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE CPP, BangPatterns, MagicHash, UnboxedTuples, RankNTypes, ScopedTypeVariables #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
+{-# LANGUAGE CPP #-}
 module Tests.Reference.Generators (
     -- * Integer with a large range
     LargeInteger(..)

--- a/cborg/tests/Tests/Reference/Generators.hs
+++ b/cborg/tests/Tests/Reference/Generators.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE CPP, BangPatterns, MagicHash, UnboxedTuples, RankNTypes, ScopedTypeVariables #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Tests.Reference.Generators (
+    -- * Integer with a large range
+    LargeInteger(..)
+
+    -- * Floats with special values
+  , FloatSpecials(..)
+
+    -- * Floating types to bit representation conversion
+  , halfToWord
+  , floatToWord
+  , doubleToWord
+  , wordToHalf
+  , wordToFloat
+  , wordToDouble
+  ) where
+
+import           Data.Word
+import           Numeric.Half as Half
+
+import           Foreign
+import           System.IO.Unsafe
+
+import           Test.QuickCheck
+
+#if !MIN_VERSION_base(4,8,0)
+import           Control.Applicative
+#endif
+
+-- | QuickCheck generator for large integers
+--
+newtype LargeInteger = LargeInteger { getLargeInteger :: Integer }
+  deriving (Show, Eq)
+
+instance Arbitrary LargeInteger where
+  arbitrary =
+    sized $ \n ->
+      oneof $ take (1 + n `div` 10)
+        [ LargeInteger .          fromIntegral <$> (arbitrary :: Gen Int8)
+        , LargeInteger .          fromIntegral <$> choose (minBound, maxBound :: Int64)
+        , LargeInteger . bigger . fromIntegral <$> choose (minBound, maxBound :: Int64)
+        ]
+    where
+      bigger n = n * abs n
+
+----------------------------------------
+-- Float <-> Integral conversions
+--
+
+wordToHalf :: Word16 -> Half
+wordToHalf = Half.Half . fromIntegral
+
+wordToFloat :: Word32 -> Float
+wordToFloat = toFloat
+
+wordToDouble :: Word64 -> Double
+wordToDouble = toFloat
+
+toFloat :: (Storable word, Storable float) => word -> float
+toFloat w =
+    unsafeDupablePerformIO $ alloca $ \buf -> do
+      poke (castPtr buf) w
+      peek buf
+
+halfToWord :: Half -> Word16
+halfToWord (Half.Half w) = fromIntegral w
+
+floatToWord :: Float -> Word32
+floatToWord = fromFloat
+
+doubleToWord :: Double -> Word64
+doubleToWord = fromFloat
+
+fromFloat :: (Storable word, Storable float) => float -> word
+fromFloat float =
+    unsafeDupablePerformIO $ alloca $ \buf -> do
+            poke (castPtr buf) float
+            peek buf
+
+
+---------------------------------------------------
+-- Generators for float types with special values
+--
+
+instance Arbitrary Half where
+  arbitrary = Half.Half . fromIntegral <$> (arbitrary :: Gen Word16)
+
+newtype FloatSpecials n = FloatSpecials { getFloatSpecials :: n }
+  deriving (Show, Eq)
+
+instance (Arbitrary n, RealFloat n) => Arbitrary (FloatSpecials n) where
+  arbitrary =
+    frequency
+      [ (7, FloatSpecials <$> arbitrary)
+      , (1, pure (FloatSpecials (1/0)) )  -- +Infinity
+      , (1, pure (FloatSpecials (0/0)) )  --  NaN
+      , (1, pure (FloatSpecials (-1/0)) ) -- -Infinity
+      ]

--- a/cborg/tests/Tests/Reference/Implementation.hs
+++ b/cborg/tests/Tests/Reference/Implementation.hs
@@ -44,6 +44,7 @@ module Tests.Reference.Implementation (
 
     diagnosticNotation,
 
+    Encoder,
     encodeTerm,
     encodeToken,
 

--- a/cborg/tests/Tests/Reference/Implementation.hs
+++ b/cborg/tests/Tests/Reference/Implementation.hs
@@ -208,6 +208,18 @@ instance Arbitrary UInt where
         , UInt32    <$> arbitraryBoundedIntegral
         , UInt64    <$> arbitraryBoundedIntegral
         ]
+  shrink (UIntSmall n) = [ UIntSmall n' | n' <- shrink n ]
+  shrink (UInt8  n)    = [ UInt8  n'    | n' <- shrink n ]
+                      ++ [ UIntSmall (fromIntegral n) | n <= 23 ]
+  shrink (UInt16 n)    = [ UInt16 n'    | n' <- shrink n ]
+                      ++ [ UInt8 (fromIntegral n)
+                         | n <= fromIntegral (maxBound :: Word8) ]
+  shrink (UInt32 n)    = [ UInt32 n'    | n' <- shrink n ]
+                      ++ [ UInt16 (fromIntegral n)
+                         | n <= fromIntegral (maxBound :: Word16) ]
+  shrink (UInt64 n)    = [ UInt64 n'    | n' <- shrink n ]
+                      ++ [ UInt32 (fromIntegral n)
+                         | n <= fromIntegral (maxBound :: Word32) ]
 
 instance Arbitrary AdditionalInformation where
   arbitrary =

--- a/cborg/tests/Tests/Reference/Implementation.hs
+++ b/cborg/tests/Tests/Reference/Implementation.hs
@@ -19,6 +19,7 @@ module Tests.Reference.Implementation (
     deserialise,
 
     Term(..),
+    Token(..),
     canonicaliseTerm,
     isCanonicalTerm,
 
@@ -41,6 +42,7 @@ module Tests.Reference.Implementation (
     decodeTerm,
     decodeTokens,
     decodeToken,
+    decodeTagged,
 
     diagnosticNotation,
 

--- a/cborg/tests/Tests/Reference/Implementation.hs
+++ b/cborg/tests/Tests/Reference/Implementation.hs
@@ -38,8 +38,6 @@ module Tests.Reference.Implementation (
     decodeTokens,
     decodeToken,
 
-    canonicalNaN,
-
     diagnosticNotation,
 
     encodeTerm,
@@ -862,8 +860,6 @@ canonicaliseFloat tfloatNN f
 canonicaliseTermPair :: (Term, Term) -> (Term, Term)
 canonicaliseTermPair (x,y) = (canonicaliseTerm x, canonicaliseTerm y)
 
-canonicalNaN :: Half
-canonicalNaN = Half 0x7e00
 
 -------------------------------------------------------------------------------
 

--- a/cborg/tests/Tests/Reference/Implementation.hs
+++ b/cborg/tests/Tests/Reference/Implementation.hs
@@ -518,11 +518,13 @@ prop_Token token =
         Just (token', []) = runDecoder decodeToken ws
      in token `eqToken` token'
 
--- NaNs are so annoying...
+-- | Compare tokens for equality, including bit for bit equality on floats.
+-- This means we can compare NaNs, and different NaNs do not compare equal.
+--
 eqToken :: Token -> Token -> Bool
-eqToken (MT7_Float16 f) (MT7_Float16 f') | isNaN f && isNaN f' = True
-eqToken (MT7_Float32 f) (MT7_Float32 f') | isNaN f && isNaN f' = True
-eqToken (MT7_Float64 f) (MT7_Float64 f') | isNaN f && isNaN f' = True
+eqToken (MT7_Float16 f) (MT7_Float16 f') = halfToWord   f == halfToWord   f'
+eqToken (MT7_Float32 f) (MT7_Float32 f') = floatToWord  f == floatToWord  f'
+eqToken (MT7_Float64 f) (MT7_Float64 f') = doubleToWord f == doubleToWord f'
 eqToken a b = a == b
 
 data Term = TUInt   UInt

--- a/cborg/tests/Tests/Reference/Implementation.hs
+++ b/cborg/tests/Tests/Reference/Implementation.hs
@@ -336,9 +336,9 @@ instance Arbitrary Token where
       , pure MT5_MapLenIndef
       , MT6_Tag     <$> arbitrary
       , MT7_Simple  <$> arbitrary
-      , MT7_Float16 . getFloatSpecials <$> arbitrary
-      , MT7_Float32 . getFloatSpecials <$> arbitrary
-      , MT7_Float64 . getFloatSpecials <$> arbitrary
+      , MT7_Float16 . getHalfSpecials   <$> arbitrary
+      , MT7_Float32 . getFloatSpecials  <$> arbitrary
+      , MT7_Float64 . getDoubleSpecials <$> arbitrary
       , pure MT7_Break
       ]
     where
@@ -555,9 +555,9 @@ instance Arbitrary Term where
         , (1, pure TNull)
         , (1, pure TUndef)
         , (1, TSimple  <$> arbitrary `suchThat` (not . reservedSimple))
-        , (1, TFloat16 <$> arbitrary)
-        , (1, TFloat32 <$> arbitrary)
-        , (1, TFloat64 <$> arbitrary)
+        , (1, TFloat16 . getHalfSpecials   <$> arbitrary)
+        , (1, TFloat32 . getFloatSpecials  <$> arbitrary)
+        , (1, TFloat64 . getDoubleSpecials <$> arbitrary)
         ]
     where
       listOfSmaller :: Gen a -> Gen [a]

--- a/cborg/tests/Tests/Reference/Implementation.hs
+++ b/cborg/tests/Tests/Reference/Implementation.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE CPP, BangPatterns, MagicHash, UnboxedTuples, RankNTypes, ScopedTypeVariables #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE CPP, BangPatterns #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      : Codec.CBOR

--- a/cborg/tests/Tests/Reference/Implementation.hs
+++ b/cborg/tests/Tests/Reference/Implementation.hs
@@ -833,13 +833,9 @@ canonicaliseTerm (TBigInt n)
   | n <  0 && n >= -1 - fromIntegral (maxBound :: Word64)
                            = TNInt (toUInt (fromIntegral (-1 - n)))
   | otherwise              = TBigInt n
-canonicaliseTerm (TFloat16 f)   = TFloat16 (canonicaliseHalf f)
-canonicaliseTerm (TFloat32 f)   = if isNaN f
-                                  then TFloat16 canonicalNaN
-                                  else TFloat32 f
-canonicaliseTerm (TFloat64 f)   = if isNaN f
-                                  then TFloat16 canonicalNaN
-                                  else TFloat64 f
+canonicaliseTerm (TFloat16 f)   = canonicaliseFloat TFloat16 f
+canonicaliseTerm (TFloat32 f)   = canonicaliseFloat TFloat32 f
+canonicaliseTerm (TFloat64 f)   = canonicaliseFloat TFloat64 f
 canonicaliseTerm (TBytess  wss) = TBytess  (filter (not . null) wss)
 canonicaliseTerm (TStrings css) = TStrings (filter (not . null) css)
 canonicaliseTerm (TArray  ts) = TArray  (map canonicaliseTerm ts)
@@ -852,10 +848,10 @@ canonicaliseTerm t = t
 canonicaliseUInt :: UInt -> UInt
 canonicaliseUInt = toUInt . fromUInt
 
-canonicaliseHalf :: Half -> Half
-canonicaliseHalf f
-  | isNaN f   = canonicalNaN
-  | otherwise = f
+canonicaliseFloat :: RealFloat t => (t -> Term) -> t -> Term
+canonicaliseFloat tfloatNN f
+  | isNaN f   = TFloat16 canonicalNaN
+  | otherwise = tfloatNN f
 
 canonicaliseTermPair :: (Term, Term) -> (Term, Term)
 canonicaliseTermPair (x,y) = (canonicaliseTerm x, canonicaliseTerm y)

--- a/cborg/tests/Tests/Term.hs
+++ b/cborg/tests/Tests/Term.hs
@@ -74,7 +74,7 @@ toRefTerm (TBool False) = Ref.TFalse
 toRefTerm (TBool True)  = Ref.TTrue
 toRefTerm  TNull        = Ref.TNull
 toRefTerm (TSimple  23) = Ref.TUndef
-toRefTerm (TSimple   w) = Ref.TSimple (fromIntegral w)
+toRefTerm (TSimple   w) = Ref.TSimple (Ref.toSimple w)
 toRefTerm (THalf     f) = if isNaN f
                           then Ref.TFloat16 canonicalNaN
                           else Ref.TFloat16 (HalfSpecials (Half.toHalf f))
@@ -115,7 +115,7 @@ fromRefTerm (Ref.TFalse)     = TBool False
 fromRefTerm (Ref.TTrue)      = TBool True
 fromRefTerm  Ref.TNull       = TNull
 fromRefTerm  Ref.TUndef      = TSimple 23
-fromRefTerm (Ref.TSimple  w) = TSimple w
+fromRefTerm (Ref.TSimple  w) = TSimple (Ref.fromSimple w)
 fromRefTerm (Ref.TFloat16 f) = THalf (Half.fromHalf (getHalfSpecials f))
 fromRefTerm (Ref.TFloat32 f) = TFloat  (getFloatSpecials  f)
 fromRefTerm (Ref.TFloat64 f) = TDouble (getDoubleSpecials f)
@@ -207,7 +207,7 @@ instance Arbitrary Term where
   shrink TNull  = []
 
   shrink (TSimple w) = [ TSimple w' | w' <- shrink w
-                       , not (Ref.reservedSimple (fromIntegral w)) ]
+                       , Ref.unassignedSimple w || w == 23 ]
   shrink (THalf  _f) = []
   shrink (TFloat  f) = [ TFloat  f' | f' <- shrink f ]
   shrink (TDouble f) = [ TDouble f' | f' <- shrink f ]

--- a/cborg/tests/Tests/Term.hs
+++ b/cborg/tests/Tests/Term.hs
@@ -44,7 +44,13 @@ serialise :: Term -> LBS.ByteString
 serialise = toLazyByteString . encodeTerm
 
 deserialise :: LBS.ByteString -> Term
-deserialise = either throw snd . deserialiseFromBytes decodeTerm
+deserialise b =
+    case deserialiseFromBytes decodeTerm b of
+      Left failure        -> throw failure
+      Right (trailing, _)  | not (LBS.null trailing)
+                          -> error "Test.deserialise: trailing data"
+      Right (_, t)        -> t
+
 
 ------------------------------------------------------------------------------
 

--- a/cborg/tests/Tests/Term.hs
+++ b/cborg/tests/Tests/Term.hs
@@ -28,7 +28,7 @@ import           Codec.CBOR.Write
 
 import           Test.QuickCheck
 
-import qualified Tests.Reference.Implementation as RefImpl
+import qualified Tests.Reference.Implementation as Ref
 import           Tests.Reference.Generators (floatToWord, doubleToWord)
 
 #if !MIN_VERSION_base(4,8,0)
@@ -47,77 +47,77 @@ deserialise = either throw snd . deserialiseFromBytes decodeTerm
 
 ------------------------------------------------------------------------------
 
-toRefTerm :: Term -> RefImpl.Term
+toRefTerm :: Term -> Ref.Term
 toRefTerm (TInt      n)
-            | n >= 0    = RefImpl.TUInt (RefImpl.toUInt (fromIntegral n))
-            | otherwise = RefImpl.TNInt (RefImpl.toUInt (fromIntegral (-1 - n)))
-toRefTerm (TInteger  n) -- = RefImpl.TBigInt n
+            | n >= 0    = Ref.TUInt (Ref.toUInt (fromIntegral n))
+            | otherwise = Ref.TNInt (Ref.toUInt (fromIntegral (-1 - n)))
+toRefTerm (TInteger  n) -- = Ref.TBigInt n
             | n >= 0 && n <= fromIntegral (maxBound :: Word64)
-                        = RefImpl.TUInt (RefImpl.toUInt (fromIntegral n))
+                        = Ref.TUInt (Ref.toUInt (fromIntegral n))
             | n <  0 && n >= -1 - fromIntegral (maxBound :: Word64)
-                        = RefImpl.TNInt (RefImpl.toUInt (fromIntegral (-1 - n)))
-            | otherwise = RefImpl.TBigInt n
-toRefTerm (TBytes   bs) = RefImpl.TBytes   (BS.unpack bs)
-toRefTerm (TBytesI  bs) = RefImpl.TBytess  (map BS.unpack (LBS.toChunks bs))
-toRefTerm (TString  st) = RefImpl.TString  (T.unpack st)
-toRefTerm (TStringI st) = RefImpl.TStrings (map T.unpack (LT.toChunks st))
-toRefTerm (TList    ts) = RefImpl.TArray   (map toRefTerm ts)
-toRefTerm (TListI   ts) = RefImpl.TArrayI  (map toRefTerm ts)
-toRefTerm (TMap     ts) = RefImpl.TMap  [ (toRefTerm x, toRefTerm y)
+                        = Ref.TNInt (Ref.toUInt (fromIntegral (-1 - n)))
+            | otherwise = Ref.TBigInt n
+toRefTerm (TBytes   bs) = Ref.TBytes   (BS.unpack bs)
+toRefTerm (TBytesI  bs) = Ref.TBytess  (map BS.unpack (LBS.toChunks bs))
+toRefTerm (TString  st) = Ref.TString  (T.unpack st)
+toRefTerm (TStringI st) = Ref.TStrings (map T.unpack (LT.toChunks st))
+toRefTerm (TList    ts) = Ref.TArray   (map toRefTerm ts)
+toRefTerm (TListI   ts) = Ref.TArrayI  (map toRefTerm ts)
+toRefTerm (TMap     ts) = Ref.TMap  [ (toRefTerm x, toRefTerm y)
                                         | (x,y) <- ts ]
-toRefTerm (TMapI    ts) = RefImpl.TMapI [ (toRefTerm x, toRefTerm y)
+toRefTerm (TMapI    ts) = Ref.TMapI [ (toRefTerm x, toRefTerm y)
                                         | (x,y) <- ts ]
-toRefTerm (TTagged w t) = RefImpl.TTagged (RefImpl.toUInt (fromIntegral w))
+toRefTerm (TTagged w t) = Ref.TTagged (Ref.toUInt (fromIntegral w))
                                           (toRefTerm t)
-toRefTerm (TBool False) = RefImpl.TFalse
-toRefTerm (TBool True)  = RefImpl.TTrue
-toRefTerm  TNull        = RefImpl.TNull
-toRefTerm (TSimple  23) = RefImpl.TUndef
-toRefTerm (TSimple   w) = RefImpl.TSimple (fromIntegral w)
+toRefTerm (TBool False) = Ref.TFalse
+toRefTerm (TBool True)  = Ref.TTrue
+toRefTerm  TNull        = Ref.TNull
+toRefTerm (TSimple  23) = Ref.TUndef
+toRefTerm (TSimple   w) = Ref.TSimple (fromIntegral w)
 toRefTerm (THalf     f) = if isNaN f
-                          then RefImpl.TFloat16 RefImpl.canonicalNaN
-                          else RefImpl.TFloat16 (Half.toHalf f)
+                          then Ref.TFloat16 Ref.canonicalNaN
+                          else Ref.TFloat16 (Half.toHalf f)
 toRefTerm (TFloat    f) = if isNaN f
-                          then RefImpl.TFloat16 RefImpl.canonicalNaN
-                          else RefImpl.TFloat32 f
+                          then Ref.TFloat16 Ref.canonicalNaN
+                          else Ref.TFloat32 f
 toRefTerm (TDouble   f) = if isNaN f
-                          then RefImpl.TFloat16 RefImpl.canonicalNaN
-                          else RefImpl.TFloat64 f
+                          then Ref.TFloat16 Ref.canonicalNaN
+                          else Ref.TFloat64 f
 
 
-fromRefTerm :: RefImpl.Term -> Term
-fromRefTerm (RefImpl.TUInt u)
+fromRefTerm :: Ref.Term -> Term
+fromRefTerm (Ref.TUInt u)
   | n <= fromIntegral (maxBound :: Int) = TInt     (fromIntegral n)
   | otherwise                           = TInteger (fromIntegral n)
-  where n = RefImpl.fromUInt u
+  where n = Ref.fromUInt u
 
-fromRefTerm (RefImpl.TNInt u)
+fromRefTerm (Ref.TNInt u)
   | n <= fromIntegral (maxBound :: Int) = TInt     (-1 - fromIntegral n)
   | otherwise                           = TInteger (-1 - fromIntegral n)
-  where n = RefImpl.fromUInt u
+  where n = Ref.fromUInt u
 
-fromRefTerm (RefImpl.TBigInt   n) = TInteger n
-fromRefTerm (RefImpl.TBytes   bs) = TBytes (BS.pack bs)
-fromRefTerm (RefImpl.TBytess  bs) = TBytesI  (LBS.fromChunks (map BS.pack bs))
-fromRefTerm (RefImpl.TString  st) = TString  (T.pack st)
-fromRefTerm (RefImpl.TStrings st) = TStringI (LT.fromChunks (map T.pack st))
+fromRefTerm (Ref.TBigInt   n) = TInteger n
+fromRefTerm (Ref.TBytes   bs) = TBytes (BS.pack bs)
+fromRefTerm (Ref.TBytess  bs) = TBytesI  (LBS.fromChunks (map BS.pack bs))
+fromRefTerm (Ref.TString  st) = TString  (T.pack st)
+fromRefTerm (Ref.TStrings st) = TStringI (LT.fromChunks (map T.pack st))
 
-fromRefTerm (RefImpl.TArray   ts) = TList  (map fromRefTerm ts)
-fromRefTerm (RefImpl.TArrayI  ts) = TListI (map fromRefTerm ts)
-fromRefTerm (RefImpl.TMap     ts) = TMap  [ (fromRefTerm x, fromRefTerm y)
-                                          | (x,y) <- ts ]
-fromRefTerm (RefImpl.TMapI    ts) = TMapI [ (fromRefTerm x, fromRefTerm y)
-                                          | (x,y) <- ts ]
-fromRefTerm (RefImpl.TTagged w t) = TTagged (RefImpl.fromUInt w)
-                                            (fromRefTerm t)
-fromRefTerm (RefImpl.TFalse)     = TBool False
-fromRefTerm (RefImpl.TTrue)      = TBool True
-fromRefTerm  RefImpl.TNull       = TNull
-fromRefTerm  RefImpl.TUndef      = TSimple 23
-fromRefTerm (RefImpl.TSimple  w) = TSimple w
-fromRefTerm (RefImpl.TFloat16 f) = THalf (Half.fromHalf f)
-fromRefTerm (RefImpl.TFloat32 f) = TFloat f
-fromRefTerm (RefImpl.TFloat64 f) = TDouble f
+fromRefTerm (Ref.TArray   ts) = TList  (map fromRefTerm ts)
+fromRefTerm (Ref.TArrayI  ts) = TListI (map fromRefTerm ts)
+fromRefTerm (Ref.TMap     ts) = TMap  [ (fromRefTerm x, fromRefTerm y)
+                                      | (x,y) <- ts ]
+fromRefTerm (Ref.TMapI    ts) = TMapI [ (fromRefTerm x, fromRefTerm y)
+                                      | (x,y) <- ts ]
+fromRefTerm (Ref.TTagged w t) = TTagged (Ref.fromUInt w)
+                                        (fromRefTerm t)
+fromRefTerm (Ref.TFalse)     = TBool False
+fromRefTerm (Ref.TTrue)      = TBool True
+fromRefTerm  Ref.TNull       = TNull
+fromRefTerm  Ref.TUndef      = TSimple 23
+fromRefTerm (Ref.TSimple  w) = TSimple w
+fromRefTerm (Ref.TFloat16 f) = THalf (Half.fromHalf f)
+fromRefTerm (Ref.TFloat32 f) = TFloat f
+fromRefTerm (Ref.TFloat64 f) = TDouble f
 
 -- | Compare terms for equality.
 --
@@ -158,7 +158,7 @@ canonicaliseTermNaNs (TTagged tag t) = TTagged tag (canonicaliseTermNaNs t)
 canonicaliseTermNaNs t = t
 
 canonicalTermNaN :: Term
-canonicalTermNaN = THalf (Half.fromHalf RefImpl.canonicalNaN)
+canonicalTermNaN = THalf (Half.fromHalf Ref.canonicalNaN)
 
 canonicaliseTermNaNsPair :: (Term, Term) -> (Term, Term)
 canonicaliseTermNaNsPair (a,b) = (canonicaliseTermNaNs a, canonicaliseTermNaNs b)
@@ -179,9 +179,9 @@ canonicaliseTermIntegersPair (a,b) =
     (canonicaliseTermIntegers a, canonicaliseTermIntegers b)
 
 
-prop_fromToRefTerm :: RefImpl.Term -> Bool
+prop_fromToRefTerm :: Ref.Term -> Bool
 prop_fromToRefTerm term = toRefTerm (fromRefTerm term)
-         `RefImpl.eqTerm` RefImpl.canonicaliseTerm term
+         `Ref.eqTerm` Ref.canonicaliseTerm term
 
 prop_toFromRefTerm :: Term -> Bool
 prop_toFromRefTerm term = fromRefTerm (toRefTerm term)
@@ -211,13 +211,13 @@ instance Arbitrary Term where
   shrink (TMapI xys)         =         [ TMapI xys' | xys' <- shrink xys ]
 
   shrink (TTagged w t) = t : [ TTagged w' t' | (w', t') <- shrink (w, t)
-                             , not (RefImpl.reservedTag (fromIntegral w')) ]
+                             , not (Ref.reservedTag (fromIntegral w')) ]
 
   shrink (TBool _) = []
   shrink TNull  = []
 
   shrink (TSimple w) = [ TSimple w' | w' <- shrink w
-                       , not (RefImpl.reservedSimple (fromIntegral w)) ]
+                       , not (Ref.reservedSimple (fromIntegral w)) ]
   shrink (THalf  _f) = []
   shrink (TFloat  f) = [ TFloat  f' | f' <- shrink f ]
   shrink (TDouble f) = [ TDouble f' | f' <- shrink f ]

--- a/cborg/tests/Tests/Term.hs
+++ b/cborg/tests/Tests/Term.hs
@@ -29,7 +29,8 @@ import           Codec.CBOR.Write
 import           Test.QuickCheck
 
 import qualified Tests.Reference.Implementation as Ref
-import           Tests.Reference.Generators (floatToWord, doubleToWord)
+import           Tests.Reference.Generators
+                   ( floatToWord, doubleToWord, canonicalNaN )
 
 #if !MIN_VERSION_base(4,8,0)
 import           Control.Applicative
@@ -75,13 +76,13 @@ toRefTerm  TNull        = Ref.TNull
 toRefTerm (TSimple  23) = Ref.TUndef
 toRefTerm (TSimple   w) = Ref.TSimple (fromIntegral w)
 toRefTerm (THalf     f) = if isNaN f
-                          then Ref.TFloat16 Ref.canonicalNaN
+                          then Ref.TFloat16 canonicalNaN
                           else Ref.TFloat16 (Half.toHalf f)
 toRefTerm (TFloat    f) = if isNaN f
-                          then Ref.TFloat16 Ref.canonicalNaN
+                          then Ref.TFloat16 canonicalNaN
                           else Ref.TFloat32 f
 toRefTerm (TDouble   f) = if isNaN f
-                          then Ref.TFloat16 Ref.canonicalNaN
+                          then Ref.TFloat16 canonicalNaN
                           else Ref.TFloat64 f
 
 
@@ -158,7 +159,7 @@ canonicaliseTermNaNs (TTagged tag t) = TTagged tag (canonicaliseTermNaNs t)
 canonicaliseTermNaNs t = t
 
 canonicalTermNaN :: Term
-canonicalTermNaN = THalf (Half.fromHalf Ref.canonicalNaN)
+canonicalTermNaN = THalf canonicalNaN
 
 canonicaliseTermNaNsPair :: (Term, Term) -> (Term, Term)
 canonicaliseTermNaNsPair (a,b) = (canonicaliseTermNaNs a, canonicaliseTermNaNs b)

--- a/cborg/tests/Tests/UnitTests.hs
+++ b/cborg/tests/Tests/UnitTests.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE NamedFieldPuns    #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Tests.UnitTests (testTree) where
+
+import qualified Data.ByteString.Lazy as LBS
+
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.HUnit (Assertion, testCase, assertEqual, (@=?))
+
+import qualified Tests.Reference.Implementation as RefImpl
+import           Tests.Reference.TestVectors
+import           Tests.Reference (termToJson, equalJson)
+import           Tests.Term as Term (toRefTerm, serialise, deserialise)
+
+#if !MIN_VERSION_base(4,8,0)
+import           Control.Applicative
+#endif
+
+
+-------------------------------------------------------------------------------
+-- Unit tests for test vector from CBOR spec RFC7049 Appendix A
+--
+
+unit_externalTestVector :: [ExternalTestCase] -> Assertion
+unit_externalTestVector = mapM_ unit_externalTestCase
+
+unit_externalTestCase :: ExternalTestCase -> Assertion
+unit_externalTestCase ExternalTestCase {
+                        encoded,
+                        decoded = Left expectedJson
+                      } = do
+  let term       = deserialise encoded
+      actualJson = termToJson (toRefTerm term)
+      reencoded  = serialise term
+
+  expectedJson `equalJson` actualJson
+  encoded @=? reencoded
+
+unit_externalTestCase ExternalTestCase {
+                        encoded,
+                        decoded = Right expectedDiagnostic
+                      } = do
+  let term             = deserialise encoded
+      actualDiagnostic = RefImpl.diagnosticNotation (toRefTerm term)
+      reencoded        = serialise term
+
+  expectedDiagnostic @=? actualDiagnostic
+  encoded @=? reencoded
+
+
+-------------------------------------------------------------------------------
+-- Unit tests for test vector from CBOR spec RFC7049 Appendix A
+--
+
+unit_expectedDiagnosticNotation :: RFC7049TestCase -> Assertion
+unit_expectedDiagnosticNotation RFC7049TestCase {
+                                  expectedDiagnostic,
+                                  encodedBytes
+                                } = do
+  let term             = deserialise (LBS.pack encodedBytes)
+      actualDiagnostic = RefImpl.diagnosticNotation (toRefTerm term)
+
+  expectedDiagnostic @=? actualDiagnostic
+
+-- | The reference implementation satisfies the roundtrip property for most
+-- examples (all the ones from Appendix A). It does not satisfy the roundtrip
+-- property in general however, non-canonical over-long int encodings for
+-- example.
+--
+unit_encodedRoundtrip :: RFC7049TestCase -> Assertion
+unit_encodedRoundtrip RFC7049TestCase {
+                        expectedDiagnostic,
+                        encodedBytes
+                      } = do
+  let term           = deserialise (LBS.pack encodedBytes)
+      reencodedBytes = LBS.unpack (serialise term)
+
+  assertEqual ("for CBOR: " ++ expectedDiagnostic) encodedBytes reencodedBytes
+
+
+--------------------------------------------------------------------------------
+-- TestTree API
+
+testTree :: TestTree
+testTree =
+  testGroup "unit tests"
+    [ testCase "RFC7049 test vector: decode" $
+        mapM_ unit_expectedDiagnosticNotation rfc7049TestVector
+
+    , testCase "RFC7049 test vector: roundtrip" $
+        mapM_ unit_encodedRoundtrip rfc7049TestVector
+
+    , withExternalTestVector $ \getTestVector ->
+      testCase "external test vector" $
+        getTestVector >>= unit_externalTestVector
+    ]

--- a/cborg/tests/Tests/UnitTests.hs
+++ b/cborg/tests/Tests/UnitTests.hs
@@ -8,7 +8,7 @@ import qualified Data.ByteString.Lazy as LBS
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.HUnit (Assertion, testCase, assertEqual, (@=?))
 
-import qualified Tests.Reference.Implementation as RefImpl
+import qualified Tests.Reference.Implementation as Ref
 import           Tests.Reference.TestVectors
 import           Tests.Reference (termToJson, equalJson)
 import           Tests.Term as Term (toRefTerm, serialise, deserialise)
@@ -30,9 +30,9 @@ unit_externalTestCase ExternalTestCase {
                         encoded,
                         decoded = Left expectedJson
                       } = do
-  let term       = deserialise encoded
+  let term       = Term.deserialise encoded
       actualJson = termToJson (toRefTerm term)
-      reencoded  = serialise term
+      reencoded  = Term.serialise term
 
   expectedJson `equalJson` actualJson
   encoded @=? reencoded
@@ -41,9 +41,9 @@ unit_externalTestCase ExternalTestCase {
                         encoded,
                         decoded = Right expectedDiagnostic
                       } = do
-  let term             = deserialise encoded
-      actualDiagnostic = RefImpl.diagnosticNotation (toRefTerm term)
-      reencoded        = serialise term
+  let term             = Term.deserialise encoded
+      actualDiagnostic = Ref.diagnosticNotation (toRefTerm term)
+      reencoded        = Term.serialise term
 
   expectedDiagnostic @=? actualDiagnostic
   encoded @=? reencoded
@@ -58,8 +58,8 @@ unit_expectedDiagnosticNotation RFC7049TestCase {
                                   expectedDiagnostic,
                                   encodedBytes
                                 } = do
-  let term             = deserialise (LBS.pack encodedBytes)
-      actualDiagnostic = RefImpl.diagnosticNotation (toRefTerm term)
+  let term             = Term.deserialise (LBS.pack encodedBytes)
+      actualDiagnostic = Ref.diagnosticNotation (toRefTerm term)
 
   expectedDiagnostic @=? actualDiagnostic
 
@@ -73,8 +73,8 @@ unit_encodedRoundtrip RFC7049TestCase {
                         expectedDiagnostic,
                         encodedBytes
                       } = do
-  let term           = deserialise (LBS.pack encodedBytes)
-      reencodedBytes = LBS.unpack (serialise term)
+  let term           = Term.deserialise (LBS.pack encodedBytes)
+      reencodedBytes = LBS.unpack (Term.serialise term)
 
   assertEqual ("for CBOR: " ++ expectedDiagnostic) encodedBytes reencodedBytes
 

--- a/serialise/tests/Tests/Orphanage.hs
+++ b/serialise/tests/Tests/Orphanage.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 module Tests.Orphanage where
 
-#if !MIN_VERSION_base(4,8,0) && !MIN_VERSION_QuickCheck(2,10,0)
+#if !MIN_VERSION_base(4,8,0)
 import           Control.Applicative
 import           Data.Monoid as Monoid
 #endif
@@ -15,8 +15,8 @@ import qualified Data.Semigroup as Semigroup
 
 import           GHC.Fingerprint.Type
 import           Data.Ord
-#if !MIN_VERSION_QuickCheck(2,10,0)
 import           Data.Typeable
+#if !MIN_VERSION_QuickCheck(2,10,0)
 import           Foreign.C.Types
 import           System.Exit (ExitCode(..))
 
@@ -26,7 +26,10 @@ import           Test.QuickCheck.Gen
 import           Test.QuickCheck.Arbitrary
 
 import qualified Data.Vector.Primitive      as Vector.Primitive
--- import qualified Data.ByteString.Short      as BSS
+#if !MIN_VERSION_quickcheck_instances(0,3,17)
+import qualified Data.ByteString.Short      as BSS
+#endif
+
 
 --------------------------------------------------------------------------------
 -- QuickCheck Orphans

--- a/serialise/tests/Tests/Serialise.hs
+++ b/serialise/tests/Tests/Serialise.hs
@@ -407,7 +407,7 @@ instance Arbitrary a => Arbitrary (List a) where
         cnv = foldr Cons Nil
 
 newtype BytesByteArray = BytesBA CBOR.BA.ByteArray
-                       deriving (Eq, Ord, Show)
+                       deriving (Eq, Ord, Show, Typeable)
 
 instance Serialise BytesByteArray where
     encode (BytesBA ba) = encodeByteArray $ CBOR.BA.toSliced ba
@@ -417,7 +417,7 @@ instance Arbitrary BytesByteArray where
     arbitrary = BytesBA . fromList <$> arbitrary
 
 newtype Utf8ByteArray = Utf8BA CBOR.BA.ByteArray
-                      deriving (Eq, Ord, Show)
+                      deriving (Eq, Ord, Show, Typeable)
 
 instance Serialise Utf8ByteArray where
     encode (Utf8BA ba) = encodeUtf8ByteArray $ CBOR.BA.toSliced ba

--- a/serialise/tests/Tests/Serialise/Canonical.hs
+++ b/serialise/tests/Tests/Serialise/Canonical.hs
@@ -1,7 +1,13 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 module Tests.Serialise.Canonical where
+
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative
+#endif
 
 import Data.Bits
 import Data.Int


### PR DESCRIPTION
* Improve the reference implementations representation
* Representations now cover more non-canonical forms
* Improve generator coverage of non-canonical forms
* systematic treatment of non-canonical floating NaNs
* new principled tests based on a commuting diagram
* tests generalised and instantiated for lots of types

This adds tests that catch the bug fixed in #183.