### PR TITLE
Bump version to GHC 8.6 and lts-13.8

### DIFF
--- a/cborg/cborg.cabal
+++ b/cborg/cborg.cabal
@@ -138,7 +138,7 @@ test-suite tests
     QuickCheck              >= 2.9     && < 2.13,
     random,
     scientific              >= 0.3     && < 0.4,
-    tasty                   >= 0.11    && < 1.2,
+    tasty                   >= 0.11    && < 1.3,
     tasty-hunit             >= 0.9     && < 0.11,
     tasty-quickcheck        >= 0.8     && < 0.11,
     vector                  >= 0.10    && < 0.13

--- a/serialise/serialise.cabal
+++ b/serialise/serialise.cabal
@@ -126,7 +126,7 @@ test-suite tests
     cborg,
     serialise,
     QuickCheck              >= 2.9     && < 2.13,
-    tasty                   >= 0.11    && < 1.2,
+    tasty                   >= 0.11    && < 1.3,
     tasty-hunit             >= 0.9     && < 0.11,
     tasty-quickcheck        >= 0.8     && < 0.11,
     quickcheck-instances    >= 0.3.12  && < 0.4,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.13
+resolver: lts-13.8
 packages:
 - 'cborg'
 - 'serialise'


### PR DESCRIPTION
Allow cborg to build with GHC 8.6 and lts=13.8