### PR TITLE
Adds required imports when OPTIMIZE_GMP is disabled

### DIFF
--- a/cborg/src/Codec/CBOR/Magic.hs
+++ b/cborg/src/Codec/CBOR/Magic.hs
@@ -107,7 +107,7 @@ import           Foreign.C (CUShort)
 
 import qualified Numeric.Half as Half
 
-#if !defined(HAVE_BYTESWAP_PRIMOPS) || !defined(MEM_UNALIGNED_OPS)
+#if !defined(HAVE_BYTESWAP_PRIMOPS) || !defined(MEM_UNALIGNED_OPS) || !defined(OPTIMIZE_GMP)
 import           Data.Bits ((.|.), unsafeShiftL)
 #endif
 


### PR DESCRIPTION
This addresses #193.

If the `OPTIMIZE_GMP` flag is set, then `Data.Bits#unsafeShiftL` is imported.

This is relatively naive in that it just chains off of the `HAVE_BYTESWAP_PRIMOPS` and `MEM_UNALIGNED_OPS` checks, but that seemed preferable to adding an extra `ifdef`.

This was tested on a local project and _seems_ to work as-expected, although I haven't had the chance to thoroughly benchmark anything.