### PR TITLE
Use replicateM to significantly increase CBOR -> JSON value parsing speed

### DIFF
--- a/cborg-json/ChangeLog.md
+++ b/cborg-json/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for cborg-json
 
+## 0.2.X.Y
+
+ * Use replicateM to significantly speed up decoding. Now faster than Aeson!
+
 ## 0.1.0.0  -- YYYY-mm-dd
 
 * First version. Released on an unsuspecting world.

--- a/cborg-json/bench/Main.hs
+++ b/cborg-json/bench/Main.hs
@@ -6,13 +6,13 @@ module Main
   ( main -- :: IO ()
   ) where
 
-import           Criterion.Main (bgroup, defaultMain, bench, nf)
+import           Criterion.Main (bgroup, defaultMain, bench, nf, whnf)
 import           Data.ByteString.Lazy (ByteString, fromStrict)
 import           Data.FileEmbed (embedFile)
 import           Data.Aeson (Value, decode, encode)
 import           Codec.CBOR.JSON (encodeValue, decodeValue)
 import           Codec.CBOR.Read (deserialiseFromBytes)
-import           Codec.CBOR.Write (toLazyByteString)
+import           Codec.CBOR.Write (toLazyByteString, toStrictByteString)
 -- import           Paths_app
 
 largeJSONBytes :: ByteString
@@ -27,12 +27,13 @@ largeCBORBytes = toLazyByteString $ encodeValue largeJSON
 main :: IO ()
 main = defaultMain
     [ bgroup "Decode"
-        [ bench "JSON" (nf (decode @Value) largeJSONBytes)
-        , bench "CBOR" (nf (deserialiseFromBytes (decodeValue False)) largeCBORBytes)
-        , bench "CBOR lenient" (nf (deserialiseFromBytes (decodeValue True)) largeCBORBytes)
+        [ bench "JSON" (whnf (decode @Value) largeJSONBytes)
+        , bench "CBOR" (whnf (deserialiseFromBytes (decodeValue False)) largeCBORBytes)
+        , bench "CBOR lenient" (whnf (deserialiseFromBytes (decodeValue True)) largeCBORBytes)
         ]
     , bgroup "Encode"
         [ bench "JSON" (nf encode largeJSON)
         , bench "CBOR" (nf (toLazyByteString . encodeValue) largeJSON)
+        , bench "CBOR strict" (whnf (toStrictByteString . encodeValue) largeJSON)
         ]
     ]

--- a/cborg-json/bench/Main.hs
+++ b/cborg-json/bench/Main.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+
+
+module Main
+  ( main -- :: IO ()
+  ) where
+
+import           Criterion.Main (bgroup, defaultMain, bench, nf)
+import           Data.ByteString.Lazy (ByteString, fromStrict)
+import           Data.FileEmbed (embedFile)
+import           Data.Aeson (Value, decode, encode)
+import           Codec.CBOR.JSON (encodeValue, decodeValue)
+import           Codec.CBOR.Read (deserialiseFromBytes)
+import           Codec.CBOR.Write (toLazyByteString)
+-- import           Paths_app
+
+largeJSONBytes :: ByteString
+largeJSONBytes = fromStrict $(embedFile "bench/availcap.czml")
+
+largeJSON :: Value
+Just largeJSON = decode largeJSONBytes
+
+largeCBORBytes :: ByteString
+largeCBORBytes = toLazyByteString $ encodeValue largeJSON
+
+main :: IO ()
+main = defaultMain
+    [ bgroup "Decode"
+        [ bench "JSON" (nf (decode @Value) largeJSONBytes)
+        , bench "CBOR" (nf (deserialiseFromBytes (decodeValue False)) largeCBORBytes)
+        , bench "CBOR lenient" (nf (deserialiseFromBytes (decodeValue True)) largeCBORBytes)
+        ]
+    , bgroup "Encode"
+        [ bench "JSON" (nf encode largeJSON)
+        , bench "CBOR" (nf (toLazyByteString . encodeValue) largeJSON)
+        ]
+    ]

--- a/cborg-json/cborg-json.cabal
+++ b/cborg-json/cborg-json.cabal
@@ -34,3 +34,26 @@ library
 
   if impl(ghc >= 8.0)
     ghc-options: -Wcompat -Wnoncanonical-monad-instances -Wnoncanonical-monadfail-instances
+
+
+
+benchmark bench
+  type:              exitcode-stdio-1.0
+  hs-source-dirs:    bench
+  main-is:           Main.hs
+
+  default-language:  Haskell2010
+  ghc-options:
+    -Wall -rtsopts -fno-cse -fno-ignore-asserts -fno-warn-orphans
+
+  other-modules:
+
+  build-depends:
+    base                    >= 4.6     && < 5.0,
+    cborg                                      ,
+    cborg-json                                 ,
+    aeson                                      ,
+    file-embed              >= 0.0.11  && < 0.1,
+    deepseq                 >= 1.0     && < 1.5,
+    criterion               >= 1.0     && < 1.6,
+    bytestring              >= 0.10.4  && < 0.11

--- a/cborg-json/cborg-json.cabal
+++ b/cborg-json/cborg-json.cabal
@@ -44,7 +44,7 @@ benchmark bench
 
   default-language:  Haskell2010
   ghc-options:
-    -Wall -rtsopts -fno-cse -fno-ignore-asserts -fno-warn-orphans
+    -Wall -rtsopts -fno-cse -fno-ignore-asserts -fno-warn-orphans -O2
 
   other-modules:
 


### PR DESCRIPTION
Adds some benchmarks for `cbor-json` to show that replacing the hand rolled implementation of `decodeListN` is much slower than using `Vector`'s `replicateM`. Results using the included 8MB real world JSON document before the change:

```
> stack bench cborg-json:bench:bench --ba "-o before-vec.html -L 100 -I 0.1"
...
cborg-json-0.2.1.0: benchmarks
Running 1 benchmarks...         
Benchmark bench: RUNNING...     
benchmarking Decode/JSON        
time                 274.7 ms   (274.5 ms .. 274.8 ms, ci 0.100)
                     0.999 R²   (0.999 R² .. 0.999 R², ci 0.100)
mean                 276.8 ms   (276.7 ms .. 277.0 ms, ci 0.100)
std dev              5.796 ms   (5.855 ms .. 6.143 ms, ci 0.100)
                                
benchmarking Decode/CBOR        
time                 512.0 ms   (511.5 ms .. 512.4 ms, ci 0.100)
                     0.999 R²   (0.999 R² .. 0.999 R², ci 0.100)
mean                 508.1 ms   (507.8 ms .. 508.6 ms, ci 0.100)
std dev              12.72 ms   (12.87 ms .. 13.51 ms, ci 0.100)
                                
benchmarking Decode/CBOR lenient
time                 528.4 ms   (526.7 ms .. 528.8 ms, ci 0.100)
                     0.995 R²   (0.995 R² .. 0.995 R², ci 0.100)
mean                 513.3 ms   (513.0 ms .. 514.1 ms, ci 0.100)
std dev              16.61 ms   (16.71 ms .. 17.85 ms, ci 0.100)
                                
benchmarking Encode/JSON        
time                 396.7 ms   (396.6 ms .. 397.0 ms, ci 0.100)
                     1.000 R²   (1.000 R² .. 1.000 R², ci 0.100)
mean                 398.3 ms   (398.2 ms .. 398.8 ms, ci 0.100)
std dev              10.42 ms   (10.44 ms .. 11.36 ms, ci 0.100)
                                
benchmarking Encode/CBOR        
time                 275.5 ms   (275.3 ms .. 275.6 ms, ci 0.100)
                     1.000 R²   (1.000 R² .. 1.000 R², ci 0.100)
mean                 277.1 ms   (277.0 ms .. 277.2 ms, ci 0.100)
std dev              4.780 ms   (4.848 ms .. 5.011 ms, ci 0.100)
                                
benchmarking Encode/CBOR strict 
time                 269.0 ms   (268.7 ms .. 269.0 ms, ci 0.100)
                     0.999 R²   (0.999 R² .. 1.000 R², ci 0.100)
mean                 270.3 ms   (270.2 ms .. 270.5 ms, ci 0.100)
std dev              3.772 ms   (3.840 ms .. 4.039 ms, ci 0.100)
                                
Benchmark bench: FINISH         
Completed 2 action(s).  
```

and after this change

```
> stack bench cborg-json:bench:bench --ba "-o after-vec.html -L 100 -I 0.1"
...
cborg-json-0.2.1.0: benchmarks
Running 1 benchmarks...         
Benchmark bench: RUNNING...     
benchmarking Decode/JSON        
time                 272.8 ms   (272.7 ms .. 273.0 ms, ci 0.100)
                     1.000 R²   (1.000 R² .. 1.000 R², ci 0.100)
mean                 276.4 ms   (276.5 ms .. 277.0 ms, ci 0.100)
std dev              8.808 ms   (8.955 ms .. 9.562 ms, ci 0.100)
variance introduced by outliers: 11% (moderately inflated)
                                
benchmarking Decode/CBOR        
time                 151.8 ms   (151.5 ms .. 151.8 ms, ci 0.100)
                     0.999 R²   (0.999 R² .. 0.999 R², ci 0.100)
mean                 150.3 ms   (150.3 ms .. 150.5 ms, ci 0.100)
std dev              3.956 ms   (4.025 ms .. 4.210 ms, ci 0.100)
                                
benchmarking Decode/CBOR lenient
time                 150.8 ms   (150.6 ms .. 150.9 ms, ci 0.100)
                     0.999 R²   (0.999 R² .. 0.999 R², ci 0.100)
mean                 150.4 ms   (150.2 ms .. 150.5 ms, ci 0.100)
std dev              5.401 ms   (5.537 ms .. 6.205 ms, ci 0.100)
variance introduced by outliers: 14% (moderately inflated)
                                
benchmarking Encode/JSON        
time                 419.1 ms   (418.9 ms .. 419.8 ms, ci 0.100)
                     0.993 R²   (0.992 R² .. 0.994 R², ci 0.100)
mean                 406.1 ms   (406.1 ms .. 407.7 ms, ci 0.100)
std dev              24.03 ms   (24.24 ms .. 25.21 ms, ci 0.100)
variance introduced by outliers: 23% (moderately inflated)
                                
benchmarking Encode/CBOR        
time                 284.8 ms   (284.7 ms .. 285.1 ms, ci 0.100)
                     0.999 R²   (0.999 R² .. 0.999 R², ci 0.100)
mean                 284.7 ms   (284.7 ms .. 284.9 ms, ci 0.100)
std dev              4.900 ms   (4.947 ms .. 5.127 ms, ci 0.100)
                                
benchmarking Encode/CBOR strict 
time                 278.0 ms   (277.8 ms .. 278.2 ms, ci 0.100)
                     0.999 R²   (0.999 R² .. 1.000 R², ci 0.100)
mean                 277.9 ms   (277.8 ms .. 278.1 ms, ci 0.100)
std dev              6.387 ms   (6.542 ms .. 7.057 ms, ci 0.100)
                                
Benchmark bench: FINISH         
Completed 2 action(s).
```

The benchmark is fairly quick and dirty, I'm happy to change It if you'd prefer not to have an 8MB JSON document in the repo.
