### PR TITLE
primitive-0.7.0.0 support

### DIFF
--- a/cborg/cborg.cabal
+++ b/cborg/cborg.cabal
@@ -82,7 +82,7 @@ library
     deepseq                 >= 1.0     && < 1.5,
     ghc-prim                >= 0.3.1.0 && < 0.6,
     half                    >= 0.2.2.3 && < 0.4,
-    primitive               >= 0.5     && < 0.7,
+    primitive               >= 0.5     && < 0.8,
     text                    >= 1.1     && < 1.3
 
   if flag(optimize-gmp)

--- a/cborg/src/Codec/CBOR/ByteArray/Sliced.hs
+++ b/cborg/src/Codec/CBOR/ByteArray/Sliced.hs
@@ -35,7 +35,9 @@ import Control.Monad.ST
 import System.IO.Unsafe
 
 import qualified Data.Primitive.ByteArray as Prim
+#if !MIN_VERSION_primitive(0,7,0)
 import           Data.Primitive.Types (Addr(..))
+#endif
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Unsafe as BS
 import qualified Data.ByteString.Short as BSS
@@ -66,7 +68,11 @@ toByteString sba =
     $ BS.unsafePackCStringFinalizer ptr (sizeofSlicedByteArray sba) (touch pinned)
   where
     pinned = toPinned sba
+#if MIN_VERSION_primitive(0,7,0)
+    !(Ptr addr#) = Prim.byteArrayContents pinned
+#else
     !(Addr addr#) = Prim.byteArrayContents pinned
+#endif
     ptr = Ptr addr#
 
 toPinned :: SlicedByteArray -> Prim.ByteArray

--- a/serialise/serialise.cabal
+++ b/serialise/serialise.cabal
@@ -71,7 +71,7 @@ library
     ghc-prim                >= 0.3.1.0 && < 0.6,
     half                    >= 0.2.2.3 && < 0.4,
     hashable                >= 1.2     && < 2.0,
-    primitive               >= 0.5     && < 0.7,
+    primitive               >= 0.5     && < 0.8,
     text                    >= 1.1     && < 1.3,
     unordered-containers    >= 0.2     && < 0.3,
     vector                  >= 0.10    && < 0.13


### PR DESCRIPTION
This patch bumps the `primitive` upper bound from `< 0.7` to `< 0.7.1`