### PR TITLE
Add an encodePreEncoded function

### DIFF
--- a/cborg/cborg.cabal
+++ b/cborg/cborg.cabal
@@ -112,6 +112,7 @@ test-suite tests
     Tests.Boundary
     Tests.ByteOffset
     Tests.Canonical
+    Tests.PreEncoded
     Tests.Regress
     Tests.Regress.Issue160
     Tests.Regress.Issue162

--- a/cborg/src/Codec/CBOR/Encoding.hs
+++ b/cborg/src/Codec/CBOR/Encoding.hs
@@ -49,6 +49,7 @@ module Codec.CBOR.Encoding
   , encodeFloat16            -- :: Float -> Encoding
   , encodeFloat              -- :: Float -> Encoding
   , encodeDouble             -- :: Double -> Encoding
+  , encodePreEncoded         -- :: B.ByteString -> Encoding
   ) where
 
 #include "cbor.h"
@@ -126,6 +127,9 @@ data Tokens =
     | TkFloat32  {-# UNPACK #-} !Float        Tokens
     | TkFloat64  {-# UNPACK #-} !Double       Tokens
     | TkBreak                                 Tokens
+
+    -- Special
+    | TkEncoded  {-# UNPACK #-} !B.ByteString Tokens
 
     | TkEnd
     deriving (Show,Eq)
@@ -348,3 +352,18 @@ encodeFloat = Encoding . TkFloat32
 -- @since 0.2.0.0
 encodeDouble :: Double -> Encoding
 encodeDouble = Encoding . TkFloat64
+
+-- | Include pre-encoded valid CBOR data into the 'Encoding'.
+--
+-- The data is included into the output as-is without any additional wrapper.
+--
+-- This should be used with care. The data /must/ be a valid CBOR encoding, but
+-- this is /not/ checked.
+--
+-- This is useful when you have CBOR data that you know is already valid, e.g.
+-- previously validated and stored on disk, and you wish to include it without
+-- having to decode and re-encode it.
+--
+-- @since 0.2.2.0
+encodePreEncoded :: B.ByteString -> Encoding
+encodePreEncoded = Encoding . TkEncoded

--- a/cborg/src/Codec/CBOR/FlatTerm.hs
+++ b/cborg/src/Codec/CBOR/FlatTerm.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP       #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE BangPatterns #-}
 
 -- |
 -- Module      : Codec.CBOR.FlatTerm
@@ -36,6 +37,7 @@ module Codec.CBOR.FlatTerm
   , toFlatTerm    -- :: Encoding -> FlatTerm
   , fromFlatTerm  -- :: Decoder s a -> FlatTerm -> Either String a
   , validFlatTerm -- :: FlatTerm -> Bool
+  , decodeTermToken -- Decoder s TermToken
   ) where
 
 #include "cbor.h"
@@ -43,6 +45,7 @@ module Codec.CBOR.FlatTerm
 import           Codec.CBOR.Encoding (Encoding(..))
 import qualified Codec.CBOR.Encoding as Enc
 import           Codec.CBOR.Decoding as Dec
+import qualified Codec.CBOR.Read     as Read
 import qualified Codec.CBOR.ByteArray        as BA
 import qualified Codec.CBOR.ByteArray.Sliced as BAS
 
@@ -60,7 +63,11 @@ import           Data.Word
 import           Data.Text (Text)
 import qualified Data.Text.Encoding as TE
 import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
 import           Control.Monad.ST
+import qualified Control.Monad.ST.Lazy as ST.Lazy
+
+import Prelude hiding (encodeFloat, decodeFloat)
 
 
 --------------------------------------------------------------------------------
@@ -141,7 +148,117 @@ convFlatTerm (Enc.TkFloat16  f  ts) = TkFloat16   f : convFlatTerm ts
 convFlatTerm (Enc.TkFloat32  f  ts) = TkFloat32   f : convFlatTerm ts
 convFlatTerm (Enc.TkFloat64  f  ts) = TkFloat64   f : convFlatTerm ts
 convFlatTerm (Enc.TkBreak       ts) = TkBreak       : convFlatTerm ts
+convFlatTerm (Enc.TkEncoded  bs ts) = decodePreEncoded bs
+                                                   ++ convFlatTerm ts
 convFlatTerm  Enc.TkEnd             = []
+
+--------------------------------------------------------------------------------
+
+decodePreEncoded :: BS.ByteString -> FlatTerm
+decodePreEncoded bs0 =
+    ST.Lazy.runST (provideInput bs0)
+  where
+    provideInput :: BS.ByteString -> ST.Lazy.ST s FlatTerm
+    provideInput bs
+      | BS.null bs = return []
+      | otherwise  = do
+          next <- ST.Lazy.strictToLazyST $ do
+              Read.Partial k <- Read.deserialiseIncremental decodeTermToken
+              k (Just bs)
+          collectOutput next
+
+    collectOutput :: Read.IDecode s TermToken -> ST.Lazy.ST s FlatTerm
+    collectOutput (Read.Fail _ _ err) = fail $ "toFlatTerm: encodePreEncoded "
+                                            ++ "used with invalid CBOR: "
+                                            ++ show err
+    collectOutput (Read.Partial    k) = ST.Lazy.strictToLazyST (k Nothing)
+                                        >>= collectOutput
+    collectOutput (Read.Done bs' _ x) = do xs <- provideInput bs'
+                                           return (x : xs)
+
+decodeTermToken :: Decoder s TermToken
+decodeTermToken = do
+    tkty <- peekTokenType
+    case tkty of
+      TypeUInt   -> do w <- decodeWord
+                       return $! fromWord w
+                    where
+                      fromWord :: Word -> TermToken
+                      fromWord w
+                        | w <= fromIntegral (maxBound :: Int)
+                                    = TkInt     (fromIntegral w)
+                        | otherwise = TkInteger (fromIntegral w)
+
+      TypeUInt64 -> do w <- decodeWord64
+                       return $! fromWord64 w
+                    where
+                      fromWord64 w
+                        | w <= fromIntegral (maxBound :: Int)
+                                    = TkInt     (fromIntegral w)
+                        | otherwise = TkInteger (fromIntegral w)
+
+      TypeNInt   -> do w <- decodeNegWord
+                       return $! fromNegWord w
+                    where
+                      fromNegWord w
+                        | w <= fromIntegral (maxBound :: Int)
+                                    = TkInt     (-1 - fromIntegral w)
+                        | otherwise = TkInteger (-1 - fromIntegral w)
+
+      TypeNInt64 -> do w <- decodeNegWord64
+                       return $! fromNegWord64 w
+                    where
+                      fromNegWord64 w
+                        | w <= fromIntegral (maxBound :: Int)
+                                    = TkInt     (-1 - fromIntegral w)
+                        | otherwise = TkInteger (-1 - fromIntegral w)
+
+      TypeInteger -> do !x <- decodeInteger
+                        return (TkInteger x)
+      TypeFloat16 -> do !x <- decodeFloat
+                        return (TkFloat16 x)
+      TypeFloat32 -> do !x <- decodeFloat
+                        return (TkFloat32 x)
+      TypeFloat64 -> do !x <- decodeDouble
+                        return (TkFloat64 x)
+
+      TypeBytes        -> do !x <- decodeBytes
+                             return (TkBytes x)
+      TypeBytesIndef   -> do decodeBytesIndef
+                             return TkBytesBegin
+      TypeString       -> do !x <- decodeString
+                             return (TkString x)
+      TypeStringIndef  -> do decodeStringIndef
+                             return TkStringBegin
+
+      TypeListLen      -> do !x <- decodeListLen
+                             return $! TkListLen (fromIntegral x)
+      TypeListLen64    -> do !x <- decodeListLen
+                             return $! TkListLen (fromIntegral x)
+      TypeListLenIndef -> do decodeListLenIndef
+                             return TkListBegin
+      TypeMapLen       -> do !x <- decodeMapLen
+                             return $! TkMapLen (fromIntegral x)
+      TypeMapLen64     -> do !x <- decodeMapLen
+                             return $! TkMapLen (fromIntegral x)
+      TypeMapLenIndef  -> do decodeMapLenIndef
+                             return TkMapBegin
+
+      TypeTag          -> do !x <- decodeTag
+                             return $! TkTag (fromIntegral x)
+      TypeTag64        -> do !x <- decodeTag
+                             return $! TkTag (fromIntegral x)
+
+      TypeBool    -> do !x <- decodeBool
+                        return (TkBool x)
+      TypeNull    -> do decodeNull
+                        return TkNull
+      TypeSimple  -> do !x <- decodeSimple
+                        return (TkSimple x)
+      TypeBreak   -> do _ <- decodeBreakOr
+                        return TkBreak
+      TypeInvalid -> fail "invalid token encoding"
+
 
 --------------------------------------------------------------------------------
 

--- a/cborg/src/Codec/CBOR/FlatTerm.hs
+++ b/cborg/src/Codec/CBOR/FlatTerm.hs
@@ -163,6 +163,10 @@ decodePreEncoded bs0 =
       | BS.null bs = return []
       | otherwise  = do
           next <- ST.Lazy.strictToLazyST $ do
+              -- This will always be a 'Partial' here because decodeTermToken
+              -- always starts by requesting initial input. Only decoders that
+              -- fail or return a value without looking at their input can give
+              -- a different initial result.
               Read.Partial k <- Read.deserialiseIncremental decodeTermToken
               k (Just bs)
           collectOutput next

--- a/cborg/src/Codec/CBOR/Pretty.hs
+++ b/cborg/src/Codec/CBOR/Pretty.hs
@@ -180,6 +180,7 @@ pprint = do
     TkFloat16  f  TkEnd -> ppTkFloat16 f
     TkFloat32  f  TkEnd -> ppTkFloat32 f
     TkFloat64  f  TkEnd -> ppTkFloat64 f
+    TkEncoded  _  TkEnd -> ppTkEncoded
     TkEnd               -> str "# End of input"
     _ -> fail $ unwords ["pprint: Unexpected token:", show term]
 
@@ -203,6 +204,9 @@ ppTkString t = str "# text" >> parens (shown t)
 
 ppTkStringBegin::               PP ()
 ppTkStringBegin = str "# text(*)" >> inc 3 >> indef pprint
+
+ppTkEncoded    ::               PP ()
+ppTkEncoded = str "# pre-encoded CBOR term"
 
 ppTkListLen    :: Word       -> PP ()
 ppTkListLen n = do
@@ -299,6 +303,7 @@ unconsToken (TkSimple w8   tks) = Just (TkSimple w8   TkEnd,tks)
 unconsToken (TkFloat16 f16 tks) = Just (TkFloat16 f16 TkEnd,tks)
 unconsToken (TkFloat32 f32 tks) = Just (TkFloat32 f32 TkEnd,tks)
 unconsToken (TkFloat64 f64 tks) = Just (TkFloat64 f64 TkEnd,tks)
+unconsToken (TkEncoded bs  tks) = Just (TkEncoded bs  TkEnd,tks)
 unconsToken (TkBreak       tks) = Just (TkBreak       TkEnd,tks)
 
 hexRep :: Tokens -> PP ()

--- a/cborg/src/Codec/CBOR/Write.hs
+++ b/cborg/src/Codec/CBOR/Write.hs
@@ -169,6 +169,10 @@ buildStep vs1 k (BI.BufferRange op0 ope0) =
           TkFloat64  f vs' -> PI.runB doubleMP   f op >>= go vs'
           TkBreak      vs' -> PI.runB breakMP   () op >>= go vs'
 
+          TkEncoded  x vs' -> BI.runBuilderWith
+                                (B.byteString x) (buildStep vs' k)
+                                (BI.BufferRange op ope0)
+
           TkEnd            -> k (BI.BufferRange op ope0)
 
       | otherwise = return $ BI.bufferFull bound op (buildStep vs k)

--- a/cborg/tests/Main.hs
+++ b/cborg/tests/Main.hs
@@ -10,6 +10,7 @@ import qualified Tests.ByteOffset as ByteOffset
 import qualified Tests.Canonical  as Canonical
 import qualified Tests.Regress    as Regress
 import qualified Tests.UTF8       as UTF8
+import qualified Tests.PreEncoded as PreEncoded
 
 main :: IO ()
 main = defaultMain tests
@@ -25,4 +26,5 @@ tests =
     , Canonical.testTree
     , Regress.testTree
     , UTF8.testTree
+    , PreEncoded.testTree
     ]

--- a/cborg/tests/Tests/PreEncoded.hs
+++ b/cborg/tests/Tests/PreEncoded.hs
@@ -1,0 +1,95 @@
+module Tests.PreEncoded (
+    testTree
+  ) where
+
+import           Data.Monoid (Monoid(mconcat))
+
+import           Codec.CBOR.Term     (Term, encodeTerm)
+import           Codec.CBOR.FlatTerm (FlatTerm, toFlatTerm, TermToken(..))
+import           Codec.CBOR.Write    (toStrictByteString, toLazyByteString)
+import           Codec.CBOR.Encoding (Encoding, encodePreEncoded)
+
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (testProperty)
+
+import           Tests.Term () -- instance Arbitrary Term
+import           Tests.Reference.Generators
+                   (canonicalNaN, floatToWord, doubleToWord)
+
+
+-- | Use 'encodePreEncoded' but with a serialised term as the bytes.
+--
+encodePreEncoded' :: Term -> Encoding
+encodePreEncoded' = encodePreEncoded . toStrictByteString . encodeTerm
+
+
+prop_preEncodedTerm_sameBytes :: Term -> Bool
+prop_preEncodedTerm_sameBytes t =
+    sameBytes
+      (encodeTerm t)
+      (encodePreEncoded' t)
+
+
+prop_preEncodedTerm_sameTokens :: Term -> Bool
+prop_preEncodedTerm_sameTokens t =
+    sameTokens
+      (encodeTerm t)
+      (encodePreEncoded' t)
+
+
+prop_preEncodedTerms_sameBytes :: [(Term, Bool)] -> Bool
+prop_preEncodedTerms_sameBytes ts  =
+    sameBytes
+      (mconcat [ encodeTerm t | (t, _) <- ts ])
+      (mconcat [ if pre then encodePreEncoded' t
+                        else encodeTerm t
+               | (t, pre) <- ts ])
+
+prop_preEncodedTerms_sameTokens :: [(Term, Bool)] -> Bool
+prop_preEncodedTerms_sameTokens ts  =
+    sameTokens
+      (mconcat [ encodeTerm t | (t, _) <- ts ])
+      (mconcat [ if pre then encodePreEncoded' t
+                        else encodeTerm t
+               | (t, pre) <- ts ])
+
+
+sameBytes :: Encoding -> Encoding -> Bool
+sameBytes e1 e2 = toLazyByteString e1 == toLazyByteString e2
+
+sameTokens :: Encoding -> Encoding -> Bool
+sameTokens e1 e2 = canonicaliseFlatTerm (toFlatTerm e1)
+      `eqFlatTerm` canonicaliseFlatTerm (toFlatTerm e2)
+
+canonicaliseFlatTerm :: FlatTerm -> FlatTerm
+canonicaliseFlatTerm = map canonicaliseTermToken
+
+canonicaliseTermToken :: TermToken -> TermToken
+canonicaliseTermToken (TkFloat16 f) | isNaN f = TkFloat16 canonicalNaN
+canonicaliseTermToken (TkFloat32 f) | isNaN f = TkFloat16 canonicalNaN
+canonicaliseTermToken (TkFloat64 f) | isNaN f = TkFloat16 canonicalNaN
+canonicaliseTermToken x = x
+
+eqFlatTerm :: FlatTerm -> FlatTerm -> Bool
+eqFlatTerm x y = and (zipWith eqTermToken x y)
+
+-- NaNs strike again!
+eqTermToken :: TermToken -> TermToken -> Bool
+eqTermToken (TkFloat16 x) (TkFloat16 y) = floatToWord  x == floatToWord  y
+eqTermToken (TkFloat32 x) (TkFloat32 y) = floatToWord  x == floatToWord  y
+eqTermToken (TkFloat64 x) (TkFloat64 y) = doubleToWord x == doubleToWord y
+eqTermToken x y = x == y
+
+
+--------------------------------------------------------------------------------
+-- TestTree API
+
+testTree :: TestTree
+testTree =
+  testGroup "pre-encoded"
+  [ testProperty "single term, same bytes"   prop_preEncodedTerm_sameBytes
+  , testProperty "single term, same tokens"  prop_preEncodedTerm_sameTokens
+  , testProperty "list terms, same bytes"    prop_preEncodedTerms_sameBytes
+  , testProperty "list terms, same tokens"   prop_preEncodedTerms_sameTokens
+  ]
+


### PR DESCRIPTION
This allows pre-encoded CBOR data to be included into an Encoding.

This is useful in cases where one has known-valid encoded CBOR data,  e.g. on disk, that you want to include into a larger CBOR data stream.  This makes it possible in such cases to avoid decoding and re-encoding.

Includes tests.

Supercedes #204 