### PR TITLE
Fix a `SomeTypeRep` tagging issue

### DIFF
--- a/serialise/src/Codec/Serialise/Class.hs
+++ b/serialise/src/Codec/Serialise/Class.hs
@@ -1216,11 +1216,11 @@ decodeSomeTypeRep = do
     case tag of
       0 | len == 1 ->
               return $! SomeTypeRep (typeRep :: TypeRep Type)
-      1 | len == 2 -> do
+      1 | len == 3 -> do
               !con <- decode
               !ks <- decode
               return $! SomeTypeRep $ mkTrCon con ks
-      2 | len == 2 -> do
+      2 | len == 3 -> do
               SomeTypeRep f <- decodeSomeTypeRep
               SomeTypeRep x <- decodeSomeTypeRep
               case typeRepKind f of
@@ -1239,7 +1239,7 @@ decodeSomeTypeRep = do
                      [ "Applied type: " ++ show f
                      , "To argument:  " ++ show x
                      ]
-      3 | len == 2 -> do
+      3 | len == 3 -> do
               SomeTypeRep arg <- decodeSomeTypeRep
               SomeTypeRep res <- decodeSomeTypeRep
               case typeRepKind arg `eqTypeRep` (typeRep :: TypeRep Type) of
@@ -1248,7 +1248,9 @@ decodeSomeTypeRep = do
                       Just HRefl -> return $! SomeTypeRep $ Fun arg res
                       Nothing -> failure "Kind mismatch" []
                 Nothing -> failure "Kind mismatch" []
-      _ -> failure "unexpected tag" []
+      _ -> failure "unexpected tag"
+           [ "Tag: " ++ show tag
+           , "Len: " ++ show len ]
   where
     failure description info =
         fail $ unlines $ [ "Codec.CBOR.Class.decodeSomeTypeRep: "++description ]

--- a/serialise/tests/Tests/Orphanage.hs
+++ b/serialise/tests/Tests/Orphanage.hs
@@ -1,6 +1,10 @@
 {-# LANGUAGE CPP                #-}
+{-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE StandaloneDeriving #-}
+#if MIN_VERSION_base(4,10,0)
+{-# LANGUAGE TypeApplications   #-}
+#endif
 module Tests.Orphanage where
 
 #if !MIN_VERSION_base(4,8,0)
@@ -10,6 +14,11 @@ import           Data.Monoid as Monoid
 
 #if MIN_VERSION_base(4,9,0) && !MIN_VERSION_QuickCheck(2,10,0)
 import qualified Data.Semigroup as Semigroup
+#endif
+
+#if MIN_VERSION_base(4,10,0)
+import           Data.Proxy
+import qualified Type.Reflection as Refl
 #endif
 
 import           GHC.Fingerprint.Type
@@ -197,3 +206,10 @@ instance Arbitrary (Proxy a) where
 
 instance Arbitrary Fingerprint where
   arbitrary = Fingerprint <$> arbitrary <*> arbitrary
+
+#if MIN_VERSION_base(4,10,0)
+data Kind a = Type a
+
+instance Arbitrary Refl.SomeTypeRep where
+  arbitrary = return (Refl.someTypeRep $ Proxy @([Either (Maybe Int) (Proxy ('Type String))]))
+#endif

--- a/serialise/tests/Tests/Serialise.hs
+++ b/serialise/tests/Tests/Serialise.hs
@@ -19,6 +19,10 @@ import           Data.List.NonEmpty ( NonEmpty )
 import qualified Data.Semigroup as Semigroup
 #endif
 
+#if MIN_VERSION_base(4,10,0)
+import qualified Type.Reflection                as Refl
+#endif
+
 import           Data.Char (ord)
 import           Data.Complex
 import           Data.Int
@@ -177,6 +181,9 @@ testTree = testGroup "Serialise class"
       , mkTest (T :: T (Canonical Float))
       , mkTest (T :: T (Canonical Double))
       , mkTest (T :: T [()])
+#if MIN_VERSION_base(4,10,0)
+      , mkTest (T :: T (Refl.SomeTypeRep))
+#endif
 #if MIN_VERSION_base(4,9,0)
       , mkTest (T :: T (NonEmpty ()))
       , mkTest (T :: T (Semigroup.Min ()))


### PR DESCRIPTION
The demonstrator test fails:
```
type: SomeTypeRep
        cbor roundtrip:                       FAIL
          *** Failed! Exception: 'DeserialiseFailure 2 "Codec.CBOR.Class.decodeSomeTypeRep: unexpected tag\n"' (after 1 test):
          [Either (Maybe Int) (Proxy (Kind *) ('Type * [Char]))]
          Use --quickcheck-replay=754269 to reproduce.
        flat roundtrip:                       FAIL
          *** Failed! Falsified (after 1 test):
          [Either (Maybe Int) (Proxy (Kind *) ('Type * [Char]))]
          Use --quickcheck-replay=127810 to reproduce.
        flat term is valid:                   OK
          +++ OK, passed 100 tests.
```