### PR TITLE
cborg-json: Decode 16- and 32-bit floats too

### DIFF
--- a/cborg-json/ChangeLog.md
+++ b/cborg-json/ChangeLog.md
@@ -1,5 +1,8 @@
 # Revision history for cborg-json
 
+* Add support for decoding half-precision and single-precision floating-point
+  numbers.
+
 ## 0.2.X.Y
 
  * Use replicateM to significantly speed up decoding. Now faster than Aeson!

--- a/cborg-json/src/Codec/CBOR/JSON.hs
+++ b/cborg-json/src/Codec/CBOR/JSON.hs
@@ -7,7 +7,7 @@ module Codec.CBOR.JSON
 
 import           Data.Monoid
 import           Control.Applicative
-import           Prelude
+import           Prelude hiding (decodeFloat)
 
 import           Codec.CBOR.Encoding
 import           Codec.CBOR.Decoding
@@ -49,6 +49,8 @@ decodeValue lenient = do
       TypeNInt    -> decodeNumberIntegral
       TypeNInt64  -> decodeNumberIntegral
       TypeInteger -> decodeNumberIntegral
+      TypeFloat16 -> decodeNumberFloat16
+      TypeFloat32 -> decodeNumberFloating
       TypeFloat64 -> decodeNumberFloating
       TypeBool    -> Bool   <$> decodeBool
       TypeNull    -> Null   <$  decodeNull
@@ -66,6 +68,13 @@ decodeNumberIntegral = Number . fromInteger <$> decodeInteger
 
 decodeNumberFloating :: Decoder s Value
 decodeNumberFloating = Number . Scientific.fromFloatDigits <$> decodeDouble
+
+decodeNumberFloat16 :: Decoder s Value
+decodeNumberFloat16 = do
+    f <- decodeFloat
+    if isNaN f || isInfinite f
+        then return Null
+        else return $ Number (Scientific.fromFloatDigits f)
 
 decodeListN :: Bool -> Int -> Decoder s Value
 decodeListN !lenient !n = do


### PR DESCRIPTION
NaNs and infinities are substituted with `null`s.

This handles all the problematic cases I had found in https://github.com/dhall-lang/dhall-haskell/issues/1350:

```
$ echo '[NaN, Infinity, -Infinity, 0.0, -0.0, 12.0]' | dhall encode > tmp
$ cabal run -- cbor-tool dump --json tmp
Up to date
[
    4,
    null,
    null,
    null,
    null,
    0,
    0,
    12
]
```

(The first `4` and `null` are Dhall's tags for a `List`.)

Partially addresses #145.