### PR TITLE
Make Decoder a newtype

### DIFF
--- a/cborg/src/Codec/CBOR/Decoding.hs
+++ b/cborg/src/Codec/CBOR/Decoding.hs
@@ -134,7 +134,7 @@ import           Prelude hiding (decodeFloat)
 -- logic.
 --
 -- @since 0.2.0.0
-data Decoder s a = Decoder {
+newtype Decoder s a = Decoder {
        runDecoder :: forall r. (a -> ST s (DecodeAction s r)) -> ST s (DecodeAction s r)
      }
 


### PR DESCRIPTION
Is there reason why `Decoder` is a data instead of newtype? According to micro benchmark micro/decoding/cbor this change gives speedup of 2.5% (9.5ms -> 9.3ms) with large errors

That's not much but hey, it's free!