### PR TITLE
Allow base64-bytestring 1.2

### DIFF
--- a/cborg/cborg.cabal
+++ b/cborg/cborg.cabal
@@ -140,7 +140,7 @@ test-suite tests
     text                    >= 1.1     && < 1.3,
     cborg,
     aeson                   >= 0.7     && < 1.6,
-    base64-bytestring       >= 1.0     && < 1.2,
+    base64-bytestring       >= 1.0     && < 1.3,
     base16-bytestring       >= 0.1     && < 0.2,
     deepseq                 >= 1.0     && < 1.5,
     half                    >= 0.2.2.3 && < 0.4,


### PR DESCRIPTION
Builds fine and all tests pass here.