### PR TITLE
add instances for these, strict

### DIFF
--- a/serialise/ChangeLog.md
+++ b/serialise/ChangeLog.md
@@ -1,5 +1,9 @@
 # Revision history for serialise
 
+## 0.2.4.0  -- UNRELEASED
+
+* Add instances for Data.Void, strict and these.
+
 ## 0.2.3.0  -- 2020-05-10
 
 * Bounds bumps and GHC 8.10 compatibility

--- a/serialise/serialise.cabal
+++ b/serialise/serialise.cabal
@@ -1,5 +1,5 @@
 name:                serialise
-version:             0.2.3.0
+version:             0.2.4.0
 synopsis:            A binary serialisation library for Haskell values.
 description:
   This package (formerly @binary-serialise-cbor@) provides pure, efficient

--- a/serialise/serialise.cabal
+++ b/serialise/serialise.cabal
@@ -72,7 +72,9 @@ library
     half                    >= 0.2.2.3 && < 0.4,
     hashable                >= 1.2     && < 2.0,
     primitive               >= 0.5     && < 0.8,
+    strict                  >= 0.4     && < 0.5,
     text                    >= 1.1     && < 1.3,
+    these                   >= 1.1     && < 1.2,
     unordered-containers    >= 0.2     && < 0.3,
     vector                  >= 0.10    && < 0.13
 

--- a/serialise/src/Codec/Serialise/Class.hs
+++ b/serialise/src/Codec/Serialise/Class.hs
@@ -70,10 +70,12 @@ import qualified Data.ByteString.Lazy                as BS.Lazy
 import qualified Data.Map                            as Map
 import qualified Data.Sequence                       as Sequence
 import qualified Data.Set                            as Set
+import qualified Data.Strict                         as Strict
 import qualified Data.IntSet                         as IntSet
 import qualified Data.IntMap                         as IntMap
 import qualified Data.HashSet                        as HashSet
 import qualified Data.HashMap.Strict                 as HashMap
+import qualified Data.These                          as These
 import qualified Data.Tree                           as Tree
 import qualified Data.Primitive.ByteArray            as Prim
 import qualified Data.Vector                         as Vector
@@ -849,6 +851,44 @@ instance (Serialise a, Serialise b) => Serialise (Either a b) where
                   1 -> do !x <- decode
                           return (Right x)
                   _ -> fail "unknown tag"
+
+-- | @since 0.2.3.1
+instance (Serialise a, Serialise b) => Serialise (These.These a b) where
+    encode (These.This x) = encodeListLen 2 <> encodeWord 0 <> encode x
+    encode (These.That x) = encodeListLen 2 <> encodeWord 1 <> encode x
+    encode (These.These x y) = encodeListLen 3 <> encodeWord 2 <> encode x <> encode y
+
+    decode = do n <- decodeListLen
+                t <- decodeWord
+                case (t, n) of
+                  (0, 2) -> do !x <- decode
+                               return (These.This x)
+                  (1, 2) -> do !x <- decode
+                               return (These.That x)
+                  (2, 3) -> do !x <- decode
+                               !y <- decode
+                               return (These.These x y)
+                  _ -> fail "unknown tag"
+
+-- | @since 0.2.3.1
+instance (Serialise a, Serialise b) => Serialise (Strict.Pair a b) where
+    encode = encode . Strict.toLazy
+    decode = Strict.toStrict <$> decode
+
+-- | @since 0.2.3.1
+instance Serialise a => Serialise (Strict.Maybe a) where
+    encode = encode . Strict.toLazy
+    decode = Strict.toStrict <$> decode
+
+-- | @since 0.2.3.1
+instance (Serialise a, Serialise b) => Serialise (Strict.Either a b) where
+    encode = encode . Strict.toLazy
+    decode = Strict.toStrict <$> decode
+
+-- | @since 0.2.3.1
+instance (Serialise a, Serialise b) => Serialise (Strict.These a b) where
+    encode = encode . Strict.toLazy
+    decode = Strict.toStrict <$> decode
 
 
 --------------------------------------------------------------------------------

--- a/serialise/src/Codec/Serialise/Class.hs
+++ b/serialise/src/Codec/Serialise/Class.hs
@@ -51,6 +51,7 @@ import           Data.Ord
 #if MIN_VERSION_base(4,8,0)
 import           Numeric.Natural
 import           Data.Functor.Identity
+import           Data.Void                           (Void, absurd)
 #endif
 
 #if MIN_VERSION_base(4,9,0)
@@ -205,6 +206,13 @@ instance Serialise a => Serialise (NonEmpty.NonEmpty a) where
 
 --------------------------------------------------------------------------------
 -- Primitive and integral instances
+
+#if MIN_VERSION_base(4,8,0)
+-- | @since 0.2.3.1
+instance Serialise Void where
+    encode = absurd
+    decode = fail "tried to decode void"
+#endif
 
 -- | @since 0.2.0.0
 instance Serialise () where

--- a/serialise/src/Codec/Serialise/Class.hs
+++ b/serialise/src/Codec/Serialise/Class.hs
@@ -208,7 +208,7 @@ instance Serialise a => Serialise (NonEmpty.NonEmpty a) where
 -- Primitive and integral instances
 
 #if MIN_VERSION_base(4,8,0)
--- | @since 0.2.3.1
+-- | @since 0.2.4.0
 instance Serialise Void where
     encode = absurd
     decode = fail "tried to decode void"
@@ -860,7 +860,7 @@ instance (Serialise a, Serialise b) => Serialise (Either a b) where
                           return (Right x)
                   _ -> fail "unknown tag"
 
--- | @since 0.2.3.1
+-- | @since 0.2.4.0
 instance (Serialise a, Serialise b) => Serialise (These.These a b) where
     encode (These.This x) = encodeListLen 2 <> encodeWord 0 <> encode x
     encode (These.That x) = encodeListLen 2 <> encodeWord 1 <> encode x
@@ -878,22 +878,22 @@ instance (Serialise a, Serialise b) => Serialise (These.These a b) where
                                return (These.These x y)
                   _ -> fail "unknown tag"
 
--- | @since 0.2.3.1
+-- | @since 0.2.4.0
 instance (Serialise a, Serialise b) => Serialise (Strict.Pair a b) where
     encode = encode . Strict.toLazy
     decode = Strict.toStrict <$> decode
 
--- | @since 0.2.3.1
+-- | @since 0.2.4.0
 instance Serialise a => Serialise (Strict.Maybe a) where
     encode = encode . Strict.toLazy
     decode = Strict.toStrict <$> decode
 
--- | @since 0.2.3.1
+-- | @since 0.2.4.0
 instance (Serialise a, Serialise b) => Serialise (Strict.Either a b) where
     encode = encode . Strict.toLazy
     decode = Strict.toStrict <$> decode
 
--- | @since 0.2.3.1
+-- | @since 0.2.4.0
 instance (Serialise a, Serialise b) => Serialise (Strict.These a b) where
     encode = encode . Strict.toLazy
     decode = Strict.toStrict <$> decode


### PR DESCRIPTION
`strict` is a recently-revived library containing strict versions of some base types, which also includes strict versions of `these` - , @phadej and I have been maintaining it.

This PR contains the relevant `Serialise` instances for those types. We thought it was better to keep these instances here instead of inside `strict` itself, because `strict` is meant to be a light library with minimal dependencies. Recently `aeson` and `lens` have added instances there too, depending on `strict`.