### PR TITLE
Adds support for ByteStrings in inside JSON

### DIFF
--- a/cborg-json/cborg-json.cabal
+++ b/cborg-json/cborg-json.cabal
@@ -26,6 +26,7 @@ library
     base >=4.7 && < 4.15,
     aeson >=0.7 && <1.6,
     aeson-pretty >=0.8 && <0.9,
+    base16-bytestring >= 0.1 && <0.2,
     unordered-containers >=0.2 && <0.3,
     scientific >=0.3 && <0.4,
     text >=1.1 && <1.3,
@@ -61,3 +62,32 @@ benchmark bench
     directory,
     process,
     zlib                    >= 0.5     && < 0.7
+
+
+test-suite tests
+  type:              exitcode-stdio-1.0
+  hs-source-dirs:    tests
+  main-is:           Main.hs
+
+  default-language:  Haskell2010
+  ghc-options:
+    -Wall -fno-warn-orphans
+    -threaded -rtsopts "-with-rtsopts=-N2"
+
+  other-modules:
+
+  build-depends:
+    base                    >= 4.7     && < 4.15,
+    base-orphans,
+    base16-bytestring       >= 0.1 && <0.2,
+    bytestring              >= 0.10.4  && < 0.11,
+    cborg,
+    cborg-json,
+    aeson                   >= 0.7     && < 1.6,
+    QuickCheck              >= 2.9     && < 2.15,
+    tasty                   >= 0.11    && < 1.4,
+    tasty-hunit             >= 0.9     && < 0.11,
+    text                    >= 1.1     && < 1.3
+  if !impl(ghc >= 8.0)
+    build-depends:
+      fail                    >= 4.9.0.0 && < 4.10

--- a/cborg-json/src/Codec/CBOR/JSON.hs
+++ b/cborg-json/src/Codec/CBOR/JSON.hs
@@ -13,9 +13,11 @@ import           Codec.CBOR.Encoding
 import           Codec.CBOR.Decoding
 import           Data.Aeson                          ( Value(..) )
 import qualified Data.Aeson                          as Aeson
+import qualified Data.ByteString.Base16              as HEX
 import qualified Data.HashMap.Lazy                   as HM
 import           Data.Scientific                     as Scientific
 import qualified Data.Text                           as T
+import qualified Data.Text.Encoding                  as TE
 import qualified Data.Vector                         as V
 
 -- | Encode a JSON value into CBOR.
@@ -59,9 +61,12 @@ decodeValue lenient = do
       TypeListLen      -> decodeListLen >>= decodeListN lenient
       TypeListLenIndef -> decodeListLenIndef >> decodeListIndef lenient []
       TypeMapLen       -> decodeMapLen >>= flip (decodeMapN lenient) HM.empty
-
+      TypeBytes   -> packHex <$> decodeBytes
       _           -> fail $ "unexpected CBOR token type for a JSON value: "
                          ++ show tkty
+    where
+      packHex = String . TE.decodeLatin1 . HEX.encode
+
 
 decodeNumberIntegral :: Decoder s Value
 decodeNumberIntegral = Number . fromInteger <$> decodeInteger
@@ -78,7 +83,7 @@ decodeNumberFloat16 = do
 
 decodeListN :: Bool -> Int -> Decoder s Value
 decodeListN !lenient !n = do
-  vec <- V.replicateM n (decodeValue lenient) 
+  vec <- V.replicateM n (decodeValue lenient)
   return $! Array vec
 
 decodeListIndef :: Bool -> [Value] -> Decoder s Value

--- a/cborg-json/tests/Main.hs
+++ b/cborg-json/tests/Main.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import           Codec.CBOR.JSON
+import           Codec.CBOR.Read
+import           Data.Aeson (Value (String))
+import qualified Data.ByteString.Base16 as HEX
+import           Data.ByteString.Lazy (fromStrict)
+import           Test.Tasty (TestTree, defaultMain, testGroup)
+import           Test.Tasty.HUnit (testCase, (@=?))
+
+
+main :: IO ()
+main = do
+  defaultMain tests
+
+
+tests :: TestTree
+tests =
+  testGroup "CBOR-JSON"
+    [ testGroup "unit tests"
+        [ testCase "decode variable ByteString as HexString" $
+            Right ("", String "303132") @=? deserialiseFromBytes (decodeValue True)
+                                              (fromStrict . fst $ HEX.decode "5803303132")
+        ]
+    ]

--- a/serialise/serialise.cabal
+++ b/serialise/serialise.cabal
@@ -210,13 +210,8 @@ benchmark micro
     criterion               >= 1.0     && < 1.6,
     cereal                  >= 0.5.2.0 && < 0.6,
     cereal-vector           >= 0.2     && < 0.3,
-    semigroups              >= 0.18    && < 0.20
-  if impl(ghc >= 8.0)
-    build-depends:
-      store                   >= 0.7.1   && < 0.8
-  else
-    build-depends:
-      store                   >= 0.7.1   && < 0.7.8
+    semigroups              >= 0.18    && < 0.20,
+    store                   >= 0.7.1   && < 0.8
 
 benchmark versus
   type:              exitcode-stdio-1.0
@@ -269,13 +264,8 @@ benchmark versus
     tar                     >= 0.4     && < 0.6,
     zlib                    >= 0.5     && < 0.7,
     pretty                  >= 1.0     && < 1.2,
-    criterion               >= 1.0     && < 1.6
-  if impl(ghc >= 8.0)
-    build-depends:
-      store                   >= 0.7.1   && < 0.8
-  else
-    build-depends:
-      store                   >= 0.7.1   && < 0.7.8
+    criterion               >= 1.0     && < 1.6,
+    store                   >= 0.7.1   && < 0.8,
     semigroups
 
   if flag(newtime15)

--- a/serialise/serialise.cabal
+++ b/serialise/serialise.cabal
@@ -210,8 +210,13 @@ benchmark micro
     criterion               >= 1.0     && < 1.6,
     cereal                  >= 0.5.2.0 && < 0.6,
     cereal-vector           >= 0.2     && < 0.3,
-    semigroups              >= 0.18    && < 0.20,
-    store                   >= 0.7.1   && < 0.8
+    semigroups              >= 0.18    && < 0.20
+  if impl(ghc >= 8.0)
+    build-depends:
+      store                   >= 0.7.1   && < 0.8
+  else
+    build-depends:
+      store                   >= 0.7.1   && < 0.7.8
 
 benchmark versus
   type:              exitcode-stdio-1.0
@@ -264,8 +269,13 @@ benchmark versus
     tar                     >= 0.4     && < 0.6,
     zlib                    >= 0.5     && < 0.7,
     pretty                  >= 1.0     && < 1.2,
-    criterion               >= 1.0     && < 1.6,
-    store                   >= 0.7.1   && < 0.8,
+    criterion               >= 1.0     && < 1.6
+  if impl(ghc >= 8.0)
+    build-depends:
+      store                   >= 0.7.1   && < 0.8
+  else
+    build-depends:
+      store                   >= 0.7.1   && < 0.7.8
     semigroups
 
   if flag(newtime15)


### PR DESCRIPTION
I am implementing WebAuthn authentication.
Chrome browser returns part of data encoded in CBOR and uses 58/59 bytes (fixed byte string with length up to 255/65535 bytes) to encode key.

I think exposing such type as a hex string in JSON is best option.
Aeson.Array Number is much less efficient.

+ extra dependency on base16