### PR TITLE
Add support for bytestring 0.11

### DIFF
--- a/cbor-tool/cbor-tool.cabal
+++ b/cbor-tool/cbor-tool.cabal
@@ -27,7 +27,7 @@ executable cbor-tool
     aeson >=0.7 && <1.6,
     aeson-pretty >=0.8 && <0.9,
     scientific >=0.3 && <0.4,
-    bytestring >=0.10 && <0.11,
+    bytestring >=0.10 && <0.12,
     unordered-containers >=0.2 && <0.3,
     text >=1.1 && <1.3,
     vector >=0.10 && <0.13,

--- a/cborg-json/cborg-json.cabal
+++ b/cborg-json/cborg-json.cabal
@@ -55,7 +55,7 @@ benchmark bench
     cborg                                      ,
     cborg-json                                 ,
     aeson                                      ,
-    bytestring              >= 0.10.4  && < 0.11,
+    bytestring              >= 0.10.4  && < 0.12,
     criterion               >= 1.0     && < 1.6,
     deepseq                 >= 1.0     && < 1.5,
     directory,

--- a/cborg/cborg.cabal
+++ b/cborg/cborg.cabal
@@ -84,7 +84,7 @@ library
   build-depends:
     array                   >= 0.4     && < 0.6,
     base                    >= 4.7     && < 4.15,
-    bytestring              >= 0.10.4  && < 0.11,
+    bytestring              >= 0.10.4  && < 0.12,
     containers              >= 0.5     && < 0.7,
     deepseq                 >= 1.0     && < 1.5,
     ghc-prim                >= 0.3.1.0 && < 0.7,
@@ -100,8 +100,12 @@ library
   if impl(ghc >= 8.0)
     ghc-options: -Wcompat -Wnoncanonical-monad-instances
   else
-    -- provide/emulate `Control.Monad.Fail` and `Data.Semigroups` API for pre-GHC8
-    build-depends: fail == 4.9.*, semigroups >=0.18 && <0.20
+    build-depends:
+      -- provide/emulate `Control.Monad.Fail` and `Data.Semigroups` API for pre-GHC8
+      fail                    == 4.9.*,
+      semigroups              >= 0.18 && < 0.20,
+      -- the `PS` pattern synonym in bytestring 0.11 is unavailable with GHC < 8.0
+      bytestring              < 0.11
 
 test-suite tests
   type:              exitcode-stdio-1.0
@@ -136,7 +140,7 @@ test-suite tests
     array                   >= 0.4     && < 0.6,
     base                    >= 4.7     && < 4.15,
     base-orphans,
-    bytestring              >= 0.10.4  && < 0.11,
+    bytestring              >= 0.10.4  && < 0.12,
     text                    >= 1.1     && < 1.3,
     cborg,
     aeson                   >= 0.7     && < 1.6,

--- a/cborg/src/Codec/CBOR/Write.hs
+++ b/cborg/src/Codec/CBOR/Write.hs
@@ -596,7 +596,11 @@ bigNatToBuilder = bigNatBuilder
     bigNatBuilder :: Gmp.BigNat -> B.Builder
     bigNatBuilder bigNat =
         let sizeW# = Gmp.sizeInBaseBigNat bigNat 256#
+#if MIN_VERSION_bytestring(0,10,12)
+            bounded = PI.boundedPrim (I# (word2Int# sizeW#)) (dumpBigNat sizeW#)
+#else
             bounded = PI.boudedPrim (I# (word2Int# sizeW#)) (dumpBigNat sizeW#)
+#endif
         in P.primBounded bytesLenMP (W# sizeW#) <> P.primBounded bounded bigNat
 
     dumpBigNat :: Word# -> Gmp.BigNat -> Ptr a -> IO (Ptr a)

--- a/serialise/serialise.cabal
+++ b/serialise/serialise.cabal
@@ -65,7 +65,7 @@ library
   build-depends:
     array                   >= 0.4     && < 0.6,
     base                    >= 4.7     && < 4.15,
-    bytestring              >= 0.10.4  && < 0.11,
+    bytestring              >= 0.10.4  && < 0.12,
     cborg                   == 0.2.*,
     containers              >= 0.5     && < 0.7,
     ghc-prim                >= 0.3.1.0 && < 0.7,
@@ -117,7 +117,7 @@ test-suite tests
 
   build-depends:
     base                    >= 4.7     && < 4.15,
-    bytestring              >= 0.10.4  && < 0.11,
+    bytestring              >= 0.10.4  && < 0.12,
     directory               >= 1.0     && < 1.4,
     filepath                >= 1.0     && < 1.5,
     text                    >= 1.1     && < 1.3,
@@ -155,7 +155,7 @@ benchmark instances
   build-depends:
     base                    >= 4.7     && < 4.15,
     binary                  >= 0.7     && < 0.11,
-    bytestring              >= 0.10.4  && < 0.11,
+    bytestring              >= 0.10.4  && < 0.12,
     vector                  >= 0.10    && < 0.13,
     cborg,
     serialise,
@@ -199,7 +199,7 @@ benchmark micro
   build-depends:
     base                    >= 4.7     && < 4.15,
     binary                  >= 0.7     && < 0.11,
-    bytestring              >= 0.10.4  && < 0.11,
+    bytestring              >= 0.10.4  && < 0.12,
     ghc-prim                >= 0.3.1.0 && < 0.7,
     vector                  >= 0.10    && < 0.13,
     cborg,
@@ -246,7 +246,7 @@ benchmark versus
     array                   >= 0.4     && < 0.6,
     base                    >= 4.7     && < 4.15,
     binary                  >= 0.7     && < 0.11,
-    bytestring              >= 0.10.4  && < 0.11,
+    bytestring              >= 0.10.4  && < 0.12,
     directory               >= 1.0     && < 1.4,
     ghc-prim                >= 0.3.1.0 && < 0.7,
     fail                    >= 4.9.0.0 && < 4.10,


### PR DESCRIPTION
http://hackage.haskell.org/package/bytestring-0.11.0.0/changelog

Since cborg uses the internal PS constructor which is a bundled pattern
synonym in bytestring >= 0.11, we stick to bytestring < 0.11 for
GHC < 8.0 where bundled pattern synonyms aren't supported.