### PR TITLE
Fix imports when `OPTIMIZE_GMP` is off

### DIFF
--- a/cborg/src/Codec/CBOR/Write.hs
+++ b/cborg/src/Codec/CBOR/Write.hs
@@ -55,6 +55,8 @@ import qualified Data.Text.Encoding                    as T
 import           Control.Exception.Base                (assert)
 import           GHC.Exts
 import           GHC.IO                                (IO(IO))
+
+#if defined(OPTIMIZE_GMP)
 #if defined(HAVE_GHC_BIGNUM)
 import qualified GHC.Num.Integer
 import qualified GHC.Num.BigNat                        as Gmp
@@ -63,6 +65,7 @@ import           GHC.Num.BigNat                        (BigNat)
 #else
 import qualified GHC.Integer.GMP.Internals             as Gmp
 import           GHC.Integer.GMP.Internals             (BigNat)
+#endif
 #endif
 
 #if __GLASGOW_HASKELL__ < 710


### PR DESCRIPTION
It looks like this was broken by the CPP changes here: https://github.com/well-typed/cborg/pull/259/commits/821a031e81417e904928eb22964bf8cc29fd6998.

[Catching this in CI](https://github.com/well-typed/cborg/issues/207) would be nice.

I'm not confident this change is actually *exactly* what's needed in all cases, but it's enough to get things running on my RPi (`integer-simple`, `-optimize-gmp`), without breaking anything on my 64-bit Linux desktop (`+optimize-gmp`).