### PR TITLE
Adapt for GHC 9.2.1

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -40,8 +40,6 @@ jobs:
             allow-failure: false
           - compiler: ghc-8.0.2
             allow-failure: false
-          - compiler: ghc-7.10.3
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt
@@ -125,7 +123,7 @@ jobs:
           echo "packages: $GITHUB_WORKSPACE/source/cborg" >> cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/cbor-tool" >> cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/serialise" >> cabal.project
-          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then echo "packages: $GITHUB_WORKSPACE/source/binary-serialise-cbor" >> cabal.project ; fi
+          echo "packages: $GITHUB_WORKSPACE/source/binary-serialise-cbor" >> cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/cborg-json" >> cabal.project
           cat cabal.project
       - name: sdist
@@ -153,7 +151,7 @@ jobs:
           echo "packages: ${PKGDIR_cborg}" >> cabal.project
           echo "packages: ${PKGDIR_cbor_tool}" >> cabal.project
           echo "packages: ${PKGDIR_serialise}" >> cabal.project
-          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then echo "packages: ${PKGDIR_binary_serialise_cbor}" >> cabal.project ; fi
+          echo "packages: ${PKGDIR_binary_serialise_cbor}" >> cabal.project
           echo "packages: ${PKGDIR_cborg_json}" >> cabal.project
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package cborg" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
@@ -161,8 +159,8 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package serialise" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90000)) -ne 0 ] ; then echo "package binary-serialise-cbor" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200 && HCNUMVER < 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package binary-serialise-cbor" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package cborg-json" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
@@ -201,8 +199,8 @@ jobs:
           ${CABAL} -vnormal check
           cd ${PKGDIR_serialise} || false
           ${CABAL} -vnormal check
-          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then cd ${PKGDIR_binary_serialise_cbor} || false ; fi
-          if [ $((HCNUMVER < 90000)) -ne 0 ] ; then ${CABAL} -vnormal check ; fi
+          cd ${PKGDIR_binary_serialise_cbor} || false
+          ${CABAL} -vnormal check
           cd ${PKGDIR_cborg_json} || false
           ${CABAL} -vnormal check
       - name: haddock

--- a/binary-serialise-cbor/binary-serialise-cbor.cabal
+++ b/binary-serialise-cbor/binary-serialise-cbor.cabal
@@ -13,7 +13,13 @@ category:            Codec
 build-type:          Simple
 cabal-version:       1.22
 tested-with:
-  GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.1
+  GHC == 8.0.2,
+  GHC == 8.2.2,
+  GHC == 8.4.4,
+  GHC == 8.6.5,
+  GHC == 8.8.3,
+  GHC == 8.10.1,
+  GHC == 9.0.1
 
 description:
   This package is a shim around @cborg@, exposing an interface compatible with

--- a/binary-serialise-cbor/binary-serialise-cbor.cabal
+++ b/binary-serialise-cbor/binary-serialise-cbor.cabal
@@ -42,7 +42,7 @@ library
   exposed-modules: Data.Binary.Serialise.CBOR.Read
 
   build-depends:
-    base >= 4.8 && < 4.16,
+    base >= 4.8 && < 4.17,
     bytestring < 1.0,
     cborg     == 0.2.*,
     serialise == 0.2.*

--- a/cbor-tool/cbor-tool.cabal
+++ b/cbor-tool/cbor-tool.cabal
@@ -22,7 +22,7 @@ executable cbor-tool
   other-extensions:    CPP, BangPatterns
   ghc-options:         -Wall
   build-depends:
-    base >=4.7 && <4.16,
+    base >=4.7 && <4.17,
     filepath >=1.0 && <1.5,
     aeson >=0.7 && <2.1,
     aeson-pretty >=0.8 && <0.9,

--- a/cbor-tool/cbor-tool.cabal
+++ b/cbor-tool/cbor-tool.cabal
@@ -15,7 +15,13 @@ build-type:          Simple
 extra-source-files:  ChangeLog.md
 cabal-version:       >=1.10
 tested-with:
-  GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.1, GHC == 9.0.1
+  GHC == 8.0.2,
+  GHC == 8.2.2,
+  GHC == 8.4.4,
+  GHC == 8.6.5,
+  GHC == 8.8.3,
+  GHC == 8.10.1,
+  GHC == 9.0.1
 
 executable cbor-tool
   main-is:             Main.hs

--- a/cborg-json/cborg-json.cabal
+++ b/cborg-json/cborg-json.cabal
@@ -17,7 +17,13 @@ build-type:          Simple
 extra-source-files:  ChangeLog.md
 cabal-version:       >=1.10
 tested-with:
-  GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.1, GHC == 9.0.1
+  GHC == 8.0.2,
+  GHC == 8.2.2,
+  GHC == 8.4.4,
+  GHC == 8.6.5,
+  GHC == 8.8.3,
+  GHC == 8.10.1,
+  GHC == 9.0.1
 
 library
   exposed-modules:     Codec.CBOR.JSON

--- a/cborg-json/cborg-json.cabal
+++ b/cborg-json/cborg-json.cabal
@@ -23,7 +23,7 @@ library
   exposed-modules:     Codec.CBOR.JSON
   ghc-options:         -Wall
   build-depends:
-    base >=4.7 && < 4.16,
+    base >=4.7 && < 4.17,
     aeson >=0.7 && <2.1,
     aeson-pretty >=0.8 && <0.9,
     unordered-containers >=0.2 && <0.3,
@@ -51,7 +51,7 @@ benchmark bench
   other-modules:
 
   build-depends:
-    base                    >= 4.6     && < 4.16,
+    base                    >= 4.6     && < 4.17,
     cborg                                      ,
     cborg-json                                 ,
     aeson                                      ,

--- a/cborg/cborg.cabal
+++ b/cborg/cborg.cabal
@@ -83,7 +83,7 @@ library
 
   build-depends:
     array                   >= 0.4     && < 0.6,
-    base                    >= 4.7     && < 4.17,
+    base                    >= 4.8     && < 4.17,
     bytestring              >= 0.10.4  && < 0.12,
     containers              >= 0.5     && < 0.7,
     deepseq                 >= 1.0     && < 1.5,

--- a/cborg/cborg.cabal
+++ b/cborg/cborg.cabal
@@ -83,11 +83,11 @@ library
 
   build-depends:
     array                   >= 0.4     && < 0.6,
-    base                    >= 4.7     && < 4.16,
+    base                    >= 4.7     && < 4.17,
     bytestring              >= 0.10.4  && < 0.12,
     containers              >= 0.5     && < 0.7,
     deepseq                 >= 1.0     && < 1.5,
-    ghc-prim                >= 0.3.1.0 && < 0.8,
+    ghc-prim                >= 0.3.1.0 && < 0.9,
     half                    >= 0.2.2.3 && < 0.4,
     primitive               >= 0.5     && < 0.8,
     text                    >= 1.1     && < 1.3 || >= 2.0 && <2.1
@@ -141,7 +141,7 @@ test-suite tests
 
   build-depends:
     array                   >= 0.4     && < 0.6,
-    base                    >= 4.7     && < 4.16,
+    base                    >= 4.7     && < 4.17,
     base-orphans,
     bytestring              >= 0.10.4  && < 0.12,
     text                    >= 1.1     && < 1.3,

--- a/cborg/cborg.cabal
+++ b/cborg/cborg.cabal
@@ -13,7 +13,13 @@ category:            Codec
 build-type:          Simple
 cabal-version:       >= 1.10
 tested-with:
-  GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.1, GHC == 9.0.1
+  GHC == 8.0.2,
+  GHC == 8.2.2,
+  GHC == 8.4.4,
+  GHC == 8.6.5,
+  GHC == 8.8.3,
+  GHC == 8.10.1,
+  GHC == 9.0.1
 
 extra-source-files:
   ChangeLog.md

--- a/cborg/src/Codec/CBOR/Decoding.hs
+++ b/cborg/src/Codec/CBOR/Decoding.hs
@@ -311,6 +311,40 @@ getDecodeAction :: Decoder s a -> ST s (DecodeAction s a)
 getDecodeAction (Decoder k) = k (\x -> return (Done x))
 
 
+-- Compatibility Shims
+toInt8   :: Int# -> Int8
+toInt16  :: Int# -> Int16
+toInt32  :: Int# -> Int32
+toInt64  :: Int# -> Int64
+toWord8  :: Word# -> Word8
+toWord16 :: Word# -> Word16
+toWord32 :: Word# -> Word32
+toWord64 :: Word# -> Word64
+#if MIN_VERSION_ghc_prim(0,8,0)
+toInt8   n = I8#  (intToInt8# n)
+toInt16  n = I16# (intToInt16# n)
+toInt32  n = I32# (intToInt32# n)
+toWord8  n = W8#  (wordToWord8# n)
+toWord16 n = W16# (wordToWord16# n)
+toWord32 n = W32# (wordToWord32# n)
+#if WORD_SIZE_IN_BITS == 64
+toInt64  n = I64# n
+toWord64 n = W64# n
+#else
+toInt64  n = I64# (intToInt64# n)
+toWord64 n = W64# (wordToWord64# n)
+#endif
+#else
+toInt8   n = I8#  n
+toInt16  n = I16# n
+toInt32  n = I32# n
+toInt64  n = I64# n
+toWord8  n = W8#  n
+toWord16 n = W16# n
+toWord32 n = W32# n
+toWord64 n = W64# n
+#endif
+
 -- $canonical
 --
 -- <https://tools.ietf.org/html/rfc7049#section-3.9>
@@ -358,21 +392,21 @@ decodeWord = Decoder (\k -> return (ConsumeWord (\w# -> k (W# w#))))
 --
 -- @since 0.2.0.0
 decodeWord8 :: Decoder s Word8
-decodeWord8 = Decoder (\k -> return (ConsumeWord8 (\w# -> k (W8# w#))))
+decodeWord8 = Decoder (\k -> return (ConsumeWord8 (\w# -> k (toWord8 w#))))
 {-# INLINE decodeWord8 #-}
 
 -- | Decode a 'Word16'.
 --
 -- @since 0.2.0.0
 decodeWord16 :: Decoder s Word16
-decodeWord16 = Decoder (\k -> return (ConsumeWord16 (\w# -> k (W16# w#))))
+decodeWord16 = Decoder (\k -> return (ConsumeWord16 (\w# -> k (toWord16 w#))))
 {-# INLINE decodeWord16 #-}
 
 -- | Decode a 'Word32'.
 --
 -- @since 0.2.0.0
 decodeWord32 :: Decoder s Word32
-decodeWord32 = Decoder (\k -> return (ConsumeWord32 (\w# -> k (W32# w#))))
+decodeWord32 = Decoder (\k -> return (ConsumeWord32 (\w# -> k (toWord32 w#))))
 {-# INLINE decodeWord32 #-}
 
 -- | Decode a 'Word64'.
@@ -382,9 +416,9 @@ decodeWord64 :: Decoder s Word64
 {-# INLINE decodeWord64 #-}
 decodeWord64 =
 #if defined(ARCH_64bit)
-  Decoder (\k -> return (ConsumeWord (\w# -> k (W64# w#))))
+  Decoder (\k -> return (ConsumeWord (\w# -> k (toWord64 w#))))
 #else
-  Decoder (\k -> return (ConsumeWord64 (\w64# -> k (W64# w64#))))
+  Decoder (\k -> return (ConsumeWord64 (\w64# -> k (toWord64 w64#))))
 #endif
 
 -- | Decode a negative 'Word'.
@@ -401,9 +435,9 @@ decodeNegWord64 :: Decoder s Word64
 {-# INLINE decodeNegWord64 #-}
 decodeNegWord64 =
 #if defined(ARCH_64bit)
-  Decoder (\k -> return (ConsumeNegWord (\w# -> k (W64# w#))))
+  Decoder (\k -> return (ConsumeNegWord (\w# -> k (toWord64 w#))))
 #else
-  Decoder (\k -> return (ConsumeNegWord64 (\w64# -> k (W64# w64#))))
+  Decoder (\k -> return (ConsumeNegWord64 (\w64# -> k (toWord64 w64#))))
 #endif
 
 -- | Decode an 'Int'.
@@ -417,21 +451,21 @@ decodeInt = Decoder (\k -> return (ConsumeInt (\n# -> k (I# n#))))
 --
 -- @since 0.2.0.0
 decodeInt8 :: Decoder s Int8
-decodeInt8 = Decoder (\k -> return (ConsumeInt8 (\w# -> k (I8# w#))))
+decodeInt8 = Decoder (\k -> return (ConsumeInt8 (\w# -> k (toInt8 w#))))
 {-# INLINE decodeInt8 #-}
 
 -- | Decode an 'Int16'.
 --
 -- @since 0.2.0.0
 decodeInt16 :: Decoder s Int16
-decodeInt16 = Decoder (\k -> return (ConsumeInt16 (\w# -> k (I16# w#))))
+decodeInt16 = Decoder (\k -> return (ConsumeInt16 (\w# -> k (toInt16 w#))))
 {-# INLINE decodeInt16 #-}
 
 -- | Decode an 'Int32'.
 --
 -- @since 0.2.0.0
 decodeInt32 :: Decoder s Int32
-decodeInt32 = Decoder (\k -> return (ConsumeInt32 (\w# -> k (I32# w#))))
+decodeInt32 = Decoder (\k -> return (ConsumeInt32 (\w# -> k (toInt32 w#))))
 {-# INLINE decodeInt32 #-}
 
 -- | Decode an 'Int64'.
@@ -441,9 +475,9 @@ decodeInt64 :: Decoder s Int64
 {-# INLINE decodeInt64 #-}
 decodeInt64 =
 #if defined(ARCH_64bit)
-  Decoder (\k -> return (ConsumeInt (\n# -> k (I64# n#))))
+  Decoder (\k -> return (ConsumeInt (\n# -> k (toInt64 n#))))
 #else
-  Decoder (\k -> return (ConsumeInt64 (\n64# -> k (I64# n64#))))
+  Decoder (\k -> return (ConsumeInt64 (\n64# -> k (toInt64 n64#))))
 #endif
 
 -- | Decode canonical representation of a 'Word'.
@@ -457,21 +491,21 @@ decodeWordCanonical = Decoder (\k -> return (ConsumeWordCanonical (\w# -> k (W# 
 --
 -- @since 0.2.0.0
 decodeWord8Canonical :: Decoder s Word8
-decodeWord8Canonical = Decoder (\k -> return (ConsumeWord8Canonical (\w# -> k (W8# w#))))
+decodeWord8Canonical = Decoder (\k -> return (ConsumeWord8Canonical (\w# -> k (toWord8 w#))))
 {-# INLINE decodeWord8Canonical #-}
 
 -- | Decode canonical representation of a 'Word16'.
 --
 -- @since 0.2.0.0
 decodeWord16Canonical :: Decoder s Word16
-decodeWord16Canonical = Decoder (\k -> return (ConsumeWord16Canonical (\w# -> k (W16# w#))))
+decodeWord16Canonical = Decoder (\k -> return (ConsumeWord16Canonical (\w# -> k (toWord16 w#))))
 {-# INLINE decodeWord16Canonical #-}
 
 -- | Decode canonical representation of a 'Word32'.
 --
 -- @since 0.2.0.0
 decodeWord32Canonical :: Decoder s Word32
-decodeWord32Canonical = Decoder (\k -> return (ConsumeWord32Canonical (\w# -> k (W32# w#))))
+decodeWord32Canonical = Decoder (\k -> return (ConsumeWord32Canonical (\w# -> k (toWord32 w#))))
 {-# INLINE decodeWord32Canonical #-}
 
 -- | Decode canonical representation of a 'Word64'.
@@ -481,9 +515,9 @@ decodeWord64Canonical :: Decoder s Word64
 {-# INLINE decodeWord64Canonical #-}
 decodeWord64Canonical =
 #if defined(ARCH_64bit)
-  Decoder (\k -> return (ConsumeWordCanonical (\w# -> k (W64# w#))))
+  Decoder (\k -> return (ConsumeWordCanonical (\w# -> k (toWord64 w#))))
 #else
-  Decoder (\k -> return (ConsumeWord64Canonical (\w64# -> k (W64# w64#))))
+  Decoder (\k -> return (ConsumeWord64Canonical (\w64# -> k (toWord64 w64#))))
 #endif
 
 -- | Decode canonical representation of a negative 'Word'.
@@ -500,9 +534,9 @@ decodeNegWord64Canonical :: Decoder s Word64
 {-# INLINE decodeNegWord64Canonical #-}
 decodeNegWord64Canonical =
 #if defined(ARCH_64bit)
-  Decoder (\k -> return (ConsumeNegWordCanonical (\w# -> k (W64# w#))))
+  Decoder (\k -> return (ConsumeNegWordCanonical (\w# -> k (toWord64 w#))))
 #else
-  Decoder (\k -> return (ConsumeNegWord64Canonical (\w64# -> k (W64# w64#))))
+  Decoder (\k -> return (ConsumeNegWord64Canonical (\w64# -> k (toWord64 w64#))))
 #endif
 
 -- | Decode canonical representation of an 'Int'.
@@ -516,21 +550,21 @@ decodeIntCanonical = Decoder (\k -> return (ConsumeIntCanonical (\n# -> k (I# n#
 --
 -- @since 0.2.0.0
 decodeInt8Canonical :: Decoder s Int8
-decodeInt8Canonical = Decoder (\k -> return (ConsumeInt8Canonical (\w# -> k (I8# w#))))
+decodeInt8Canonical = Decoder (\k -> return (ConsumeInt8Canonical (\w# -> k (toInt8 w#))))
 {-# INLINE decodeInt8Canonical #-}
 
 -- | Decode canonical representation of an 'Int16'.
 --
 -- @since 0.2.0.0
 decodeInt16Canonical :: Decoder s Int16
-decodeInt16Canonical = Decoder (\k -> return (ConsumeInt16Canonical (\w# -> k (I16# w#))))
+decodeInt16Canonical = Decoder (\k -> return (ConsumeInt16Canonical (\w# -> k (toInt16 w#))))
 {-# INLINE decodeInt16Canonical #-}
 
 -- | Decode canonical representation of an 'Int32'.
 --
 -- @since 0.2.0.0
 decodeInt32Canonical :: Decoder s Int32
-decodeInt32Canonical = Decoder (\k -> return (ConsumeInt32Canonical (\w# -> k (I32# w#))))
+decodeInt32Canonical = Decoder (\k -> return (ConsumeInt32Canonical (\w# -> k (toInt32 w#))))
 {-# INLINE decodeInt32Canonical #-}
 
 -- | Decode canonical representation of an 'Int64'.
@@ -540,9 +574,9 @@ decodeInt64Canonical :: Decoder s Int64
 {-# INLINE decodeInt64Canonical #-}
 decodeInt64Canonical =
 #if defined(ARCH_64bit)
-  Decoder (\k -> return (ConsumeIntCanonical (\n# -> k (I64# n#))))
+  Decoder (\k -> return (ConsumeIntCanonical (\n# -> k (toInt64 n#))))
 #else
-  Decoder (\k -> return (ConsumeInt64Canonical (\n64# -> k (I64# n64#))))
+  Decoder (\k -> return (ConsumeInt64Canonical (\n64# -> k (toInt64 n64#))))
 #endif
 
 -- | Decode an 'Integer'.
@@ -759,7 +793,7 @@ decodeNull = Decoder (\k -> return (ConsumeNull (k ())))
 --
 -- @since 0.2.0.0
 decodeSimple :: Decoder s Word8
-decodeSimple = Decoder (\k -> return (ConsumeSimple (\w# -> k (W8# w#))))
+decodeSimple = Decoder (\k -> return (ConsumeSimple (\w# -> k (toWord8 w#))))
 {-# INLINE decodeSimple #-}
 
 -- | Decode canonical representation of an 'Integer'.
@@ -795,7 +829,7 @@ decodeDoubleCanonical = Decoder (\k -> return (ConsumeDoubleCanonical (\f# -> k 
 --
 -- @since 0.2.0.0
 decodeSimpleCanonical :: Decoder s Word8
-decodeSimpleCanonical = Decoder (\k -> return (ConsumeSimpleCanonical (\w# -> k (W8# w#))))
+decodeSimpleCanonical = Decoder (\k -> return (ConsumeSimpleCanonical (\w# -> k (toWord8 w#))))
 {-# INLINE decodeSimpleCanonical #-}
 
 --------------------------------------------------------------

--- a/cborg/src/Codec/CBOR/FlatTerm.hs
+++ b/cborg/src/Codec/CBOR/FlatTerm.hs
@@ -55,6 +55,9 @@ import           GHC.Int   (Int64(I64#))
 import           GHC.Word  (Word64(W64#))
 import           GHC.Exts  (Word64#, Int64#)
 #endif
+#if MIN_VERSION_ghc_prim(0,8,0)
+import           GHC.Exts  (word8ToWord#)
+#endif
 import           GHC.Word  (Word(W#), Word8(W8#))
 import           GHC.Exts  (Int(I#), Int#, Word#, Float#, Double#)
 import           GHC.Float (Float(F#), Double(D#), float2Double)
@@ -714,7 +717,11 @@ unW# :: Word -> Word#
 unW#   (W#  w#) = w#
 
 unW8# :: Word8 -> Word#
+#if MIN_VERSION_ghc_prim(0,8,0)
+unW8#  (W8# w#) = word8ToWord# w#
+#else
 unW8#  (W8# w#) = w#
+#endif
 
 unF# :: Float -> Float#
 unF#   (F#   f#) = f#

--- a/cborg/src/Codec/CBOR/Magic.hs
+++ b/cborg/src/Codec/CBOR/Magic.hs
@@ -159,12 +159,17 @@ grabWord8 (Ptr ip#) = W8# (indexWord8OffAddr# ip# 0#)
 -- On x86 machines with GHC 7.10, we have byteswap primitives
 -- available to make this conversion very fast.
 
+#if MIN_VERSION_ghc_prim(0,8,0)
+grabWord16 (Ptr ip#) = W16# (wordToWord16# (byteSwap16# (word16ToWord# (indexWord16OffAddr# ip# 0#))))
+grabWord32 (Ptr ip#) = W32# (wordToWord32# (byteSwap32# (word32ToWord# (indexWord32OffAddr# ip# 0#))))
+#else
 grabWord16 (Ptr ip#) = W16# (narrow16Word# (byteSwap16# (indexWord16OffAddr# ip# 0#)))
 grabWord32 (Ptr ip#) = W32# (narrow32Word# (byteSwap32# (indexWord32OffAddr# ip# 0#)))
+#endif
 #if defined(ARCH_64bit)
 grabWord64 (Ptr ip#) = W64# (byteSwap# (indexWord64OffAddr# ip# 0#))
 #else
-grabWord64 (Ptr ip#) = W64# (byteSwap64# (indexWord64OffAddr# ip# 0#))
+grabWord64 (Ptr ip#) = W64# (byteSwap64# (word64ToWord# (indexWord64OffAddr# ip# 0#)))
 #endif
 
 #elif defined(MEM_UNALIGNED_OPS) && \
@@ -409,6 +414,19 @@ int64ToWord64 :: Int64 -> Word64
 int64ToWord64 = fromIntegral
 {-# INLINE int64ToWord64 #-}
 
+#if MIN_VERSION_ghc_prim(0,8,0)
+word8ToWord  (W8#  w#) = W# (word8ToWord# w#)
+word16ToWord (W16# w#) = W# (word16ToWord# w#)
+word32ToWord (W32# w#) = W# (word32ToWord# w#)
+#if defined(ARCH_64bit)
+word64ToWord (W64# w#) = W# w#
+#else
+word64ToWord (W64# w64#) =
+  case isTrue# (w64# `leWord64#` wordToWord64# 0xffffffff##) of
+    True  -> Just (W# (word64ToWord# w64#))
+    False -> Nothing
+#endif
+#else
 word8ToWord  (W8#  w#) = W# w#
 word16ToWord (W16# w#) = W# w#
 word32ToWord (W32# w#) = W# w#
@@ -420,12 +438,25 @@ word64ToWord (W64# w64#) =
     True  -> Just (W# (word64ToWord# w64#))
     False -> Nothing
 #endif
+#endif
 
 {-# INLINE word8ToWord #-}
 {-# INLINE word16ToWord #-}
 {-# INLINE word32ToWord #-}
 {-# INLINE word64ToWord #-}
 
+#if MIN_VERSION_ghc_prim(0,8,0)
+word8ToInt  (W8#  w#) = I# (word2Int# (word8ToWord# w#))
+word16ToInt (W16# w#) = I# (word2Int# (word16ToWord# w#))
+#if defined(ARCH_64bit)
+word32ToInt (W32# w#) = I# (word2Int# (word32ToWord# w#))
+#else
+word32ToInt (W32# w#) =
+  case isTrue# (w# `ltWord#` 0x80000000##) of
+    True  -> Just (I# (word2Int# (word32ToWord# w#)))
+    False -> Nothing
+#endif
+#else
 word8ToInt  (W8#  w#) = I# (word2Int# w#)
 word16ToInt (W16# w#) = I# (word2Int# w#)
 
@@ -436,6 +467,7 @@ word32ToInt (W32# w#) =
   case isTrue# (w# `ltWord#` 0x80000000##) of
     True  -> Just (I# (word2Int# w#))
     False -> Nothing
+#endif
 #endif
 
 #if defined(ARCH_64bit)

--- a/cborg/src/Codec/CBOR/Magic.hs
+++ b/cborg/src/Codec/CBOR/Magic.hs
@@ -48,12 +48,17 @@ module Codec.CBOR.Magic
 
   -- int*ToInt conversions are missing because they are not needed.
 
-  , word8ToInt        -- :: Int8  -> Int
-  , word16ToInt       -- :: Int16 -> Int
-  , word32ToInt       -- :: Int32 -> Int
-  , word64ToInt       -- :: Int64 -> Int
+  , word8ToInt        -- :: Word8  -> Int
+  , word16ToInt       -- :: Word16 -> Int
+  , word32ToInt       -- :: Word32 -> Int
+  , word64ToInt       -- :: Word64 -> Int
 
-  , intToInt64        -- :: Int   -> Int64
+  , intToWord         -- :: Int    -> Word
+  , intToInt64        -- :: Int    -> Int64
+
+  , intToWord64       -- :: Int    -> Word64
+  , int64ToWord64     -- :: Int64  -> Word64
+
 #if defined(ARCH_32bit)
   , word8ToInt64      -- :: Word8  -> Int64
   , word16ToInt64     -- :: Word16 -> Int64
@@ -391,6 +396,18 @@ word32ToWord64 :: Word32 -> Word64
 intToInt64 :: Int -> Int64
 intToInt64 = fromIntegral
 {-# INLINE intToInt64 #-}
+
+intToWord :: Int -> Word
+intToWord = fromIntegral
+{-# INLINE intToWord #-}
+
+intToWord64 :: Int -> Word64
+intToWord64 = fromIntegral
+{-# INLINE intToWord64 #-}
+
+int64ToWord64 :: Int64 -> Word64
+int64ToWord64 = fromIntegral
+{-# INLINE int64ToWord64 #-}
 
 word8ToWord  (W8#  w#) = W# w#
 word16ToWord (W16# w#) = W# w#

--- a/serialise/serialise.cabal
+++ b/serialise/serialise.cabal
@@ -64,11 +64,11 @@ library
 
   build-depends:
     array                   >= 0.4     && < 0.6,
-    base                    >= 4.7     && < 4.16,
+    base                    >= 4.7     && < 4.17,
     bytestring              >= 0.10.4  && < 0.12,
     cborg                   == 0.2.*,
     containers              >= 0.5     && < 0.7,
-    ghc-prim                >= 0.3.1.0 && < 0.8,
+    ghc-prim                >= 0.3.1.0 && < 0.9,
     half                    >= 0.2.2.3 && < 0.4,
     hashable                >= 1.2     && < 2.0,
     primitive               >= 0.5     && < 0.8,
@@ -80,7 +80,7 @@ library
 
   if flag(newtime15)
     build-depends:
-      time                  >= 1.5     && < 1.12
+      time                  >= 1.5     && < 1.14
   else
     build-depends:
       time                  >= 1.4     && < 1.5,
@@ -118,12 +118,12 @@ test-suite tests
     Tests.GeneralisedUTF8
 
   build-depends:
-    base                    >= 4.7     && < 4.16,
+    base                    >= 4.7     && < 4.17,
     bytestring              >= 0.10.4  && < 0.12,
     directory               >= 1.0     && < 1.4,
     filepath                >= 1.0     && < 1.5,
     text                    >= 1.1     && < 1.3,
-    time                    >= 1.4     && < 1.12,
+    time                    >= 1.4     && < 1.14,
     containers              >= 0.5     && < 0.7,
     unordered-containers    >= 0.2     && < 0.3,
     primitive               >= 0.5     && < 0.8,
@@ -155,7 +155,7 @@ benchmark instances
     Instances.Time
 
   build-depends:
-    base                    >= 4.7     && < 4.16,
+    base                    >= 4.7     && < 4.17,
     binary                  >= 0.7     && < 0.11,
     bytestring              >= 0.10.4  && < 0.12,
     vector                  >= 0.10    && < 0.13,
@@ -167,7 +167,7 @@ benchmark instances
 
   if flag(newtime15)
     build-depends:
-      time                  >= 1.5     && < 1.12
+      time                  >= 1.5     && < 1.14
   else
     build-depends:
       time                  >= 1.4     && < 1.5,
@@ -199,10 +199,10 @@ benchmark micro
     SimpleVersus
 
   build-depends:
-    base                    >= 4.7     && < 4.16,
+    base                    >= 4.7     && < 4.17,
     binary                  >= 0.7     && < 0.11,
     bytestring              >= 0.10.4  && < 0.12,
-    ghc-prim                >= 0.3.1.0 && < 0.8,
+    ghc-prim                >= 0.3.1.0 && < 0.9,
     vector                  >= 0.10    && < 0.13,
     cborg,
     serialise,
@@ -246,11 +246,11 @@ benchmark versus
 
   build-depends:
     array                   >= 0.4     && < 0.6,
-    base                    >= 4.7     && < 4.16,
+    base                    >= 4.7     && < 4.17,
     binary                  >= 0.7     && < 0.11,
     bytestring              >= 0.10.4  && < 0.12,
     directory               >= 1.0     && < 1.4,
-    ghc-prim                >= 0.3.1.0 && < 0.8,
+    ghc-prim                >= 0.3.1.0 && < 0.9,
     fail                    >= 4.9.0.0 && < 4.10,
     text                    >= 1.1     && < 1.3,
     vector                  >= 0.10    && < 0.13,
@@ -272,7 +272,7 @@ benchmark versus
 
   if flag(newtime15)
     build-depends:
-      time                  >= 1.5     && < 1.12
+      time                  >= 1.5     && < 1.14
   else
     build-depends:
       time                  >= 1.4     && < 1.5,

--- a/serialise/serialise.cabal
+++ b/serialise/serialise.cabal
@@ -30,7 +30,13 @@ cabal-version:       >=1.10
 category:            Codec
 build-type:          Simple
 tested-with:
-  GHC == 7.10.3, GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.3, GHC == 8.10.1, GHC == 9.0.1
+  GHC == 8.0.2,
+  GHC == 8.2.2,
+  GHC == 8.4.4,
+  GHC == 8.6.5,
+  GHC == 8.8.3,
+  GHC == 8.10.1,
+  GHC == 9.0.1
 
 extra-source-files:
   ChangeLog.md

--- a/serialise/tests/Tests/Serialise.hs
+++ b/serialise/tests/Tests/Serialise.hs
@@ -190,7 +190,9 @@ testTree = testGroup "Serialise class"
       , mkTest (T :: T (Semigroup.Max ()))
       , mkTest (T :: T (Semigroup.First ()))
       , mkTest (T :: T (Semigroup.Last ()))
+#if !MIN_VERSION_base(4,16,0)
       , mkTest (T :: T (Semigroup.Option ()))
+#endif
       , mkTest (T :: T (Semigroup.WrappedMonoid ()))
 #endif
 #if MIN_VERSION_base(4,7,0)


### PR DESCRIPTION
This adapts all of the `cborg` packages to compile with GHC 9.2. 