### PR TITLE
Allow semigroups-0.20

### DIFF
--- a/cborg/cborg.cabal
+++ b/cborg/cborg.cabal
@@ -112,7 +112,7 @@ library
     build-depends:
       -- provide/emulate `Control.Monad.Fail` and `Data.Semigroups` API for pre-GHC8
       fail                    == 4.9.*,
-      semigroups              >= 0.18 && < 0.20,
+      semigroups              >= 0.18 && < 0.21,
       -- the `PS` pattern synonym in bytestring 0.11 is unavailable with GHC < 8.0
       bytestring              < 0.11
 

--- a/serialise/serialise.cabal
+++ b/serialise/serialise.cabal
@@ -218,7 +218,7 @@ benchmark micro
     criterion               >= 1.0     && < 1.6,
     cereal                  >= 0.5.2.0 && < 0.6,
     cereal-vector           >= 0.2     && < 0.3,
-    semigroups              >= 0.18    && < 0.20,
+    semigroups              >= 0.18    && < 0.21,
     store                   >= 0.7.1   && < 0.8
 
 benchmark versus


### PR DESCRIPTION
I made a corresponding revision https://hackage.haskell.org/package/cborg-0.2.6.0/revisions/