### PR TITLE
Fix SlicedByteArray

### DIFF
--- a/cborg/ChangeLog.md
+++ b/cborg/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for cborg
 
+## 0.2.9.0
+
+* Fix `Eq`, `Ord`, `Show` and `IsList` instances for `SlicedByteArray` when offset is present
+* Fix `toBuilder` and `encodeByteArray` for `SlicedByteArray` when offset is present
+
 ## 0.2.8.0  -- 2022-09-24
 
 * Support GHC 9.4

--- a/cborg/src/Codec/CBOR/ByteArray/Internal.hs
+++ b/cborg/src/Codec/CBOR/ByteArray/Internal.hs
@@ -41,9 +41,10 @@ foldrByteArray :: (Word8 -> a -> a) -> a
                -> a
 foldrByteArray f z off0 len ba = go off0
   where
+    len' = len + off0
     go !off
-      | off == len = z
-      | otherwise  =
+      | off >= len' = z
+      | otherwise   =
         let x = Prim.indexByteArray ba off
         in f x (go (off+1))
 

--- a/cborg/src/Codec/CBOR/ByteArray/Sliced.hs
+++ b/cborg/src/Codec/CBOR/ByteArray/Sliced.hs
@@ -133,9 +133,10 @@ instance Eq SlicedByteArray where
     | otherwise
     = let (!) :: Prim.ByteArray -> Int -> Word8
           (!) = Prim.indexByteArray
+          -- len1 and len2 are known to be equal at this point
+          len1' = len1 + off1
           go i1 i2
-            | i1 == len1 && i2 == len2   = True
-            | i1 == len1 || i2 == len2   = False
+            | i1 == len1' = True
             | (arr1 ! i1) == (arr2 ! i2) = go (i1+1) (i2+1)
             | otherwise                  = False
       in go off1 off2
@@ -150,10 +151,12 @@ instance Ord SlicedByteArray where
     | otherwise
     = let (!) :: Prim.ByteArray -> Int -> Word8
           (!) = Prim.indexByteArray
+          len1' = len1 + off1
+          len2' = len2 + off2
           go i1 i2
-            | i1 == len1 && i2 == len2 = EQ
-            | i1 == len1 || i2 == len2 = len1 `compare` len2
-            | EQ <- o                  = go (i1+1) (i2+1)
-            | otherwise                = o
+            | i1 == len1' && i2 == len2' = EQ
+            | i1 == len1' || i2 == len2' = len1 `compare` len2
+            | EQ <- o                    = go (i1+1) (i2+1)
+            | otherwise                  = o
             where o = (arr1 ! i1) `compare` (arr2 ! i2)
       in go off1 off2

--- a/cborg/src/Codec/CBOR/ByteArray/Sliced.hs
+++ b/cborg/src/Codec/CBOR/ByteArray/Sliced.hs
@@ -84,7 +84,7 @@ toPinned (SBA ba off len)
         Prim.unsafeFreezeByteArray ba'
 
 toBuilder :: SlicedByteArray -> BSB.Builder
-toBuilder = \(SBA ba off len) -> BSB.builder (go ba off len)
+toBuilder = \(SBA ba off len) -> BSB.builder (go ba off (len + off))
   where
     go ba !ip !ipe !k (BSB.BufferRange op ope)
       | inpRemaining <= outRemaining = do


### PR DESCRIPTION
Implementation of `SlicedByteArray` is totally wrong whenever offset is present. This was discovered when roundtrip property was implemented elsewhere.