### PR TITLE
Compatibility with ghc-prim-0.9.0.0 on 64 bit

### DIFF
--- a/cborg/src/Codec/CBOR/Magic.hs
+++ b/cborg/src/Codec/CBOR/Magic.hs
@@ -257,7 +257,13 @@ grabWord64 (Ptr ip#) =
 #endif
 
 #if WORD_SIZE_IN_BITS == 64
+
+#if MIN_VERSION_ghc_prim(0,9,0)
+    w64 w# = W64# (wordToWord64# (toWord w#))
+#else
     w64 w# = W64# (toWord w#)
+#endif
+
 #else
     w64 w# = W64# (wordToWord64# (toWord w#))
 #endif


### PR DESCRIPTION
Without this patch the build fails with ghc-9.4.1 on my machine. Places for word16 and word32 look very similar already.