### PR TITLE
Make `tokenTypeOf` more precise

### DIFF
--- a/cborg/src/Codec/CBOR/FlatTerm.hs
+++ b/cborg/src/Codec/CBOR/FlatTerm.hs
@@ -565,7 +565,7 @@ tokenTypeOf (TkInt n)
     | n >= 0                          = TypeUInt
     | otherwise                       = TypeNInt
 tokenTypeOf (TkInteger n)   -- See https://github.com/well-typed/cborg/issues/324
-  | 0 <= n && n <= 0xffffffffffffffff = TypeUInt64
+  | 0 <= n && n <= 0xffffffffffffffff = TypeUInt64 -- 0xffffffffffffffff == 2^64 - 1
   | -0xffffffffffffffff <= n && n < 0 = TypeNInt64
   | otherwise                         = TypeInteger
 tokenTypeOf TkBytes{}                 = TypeBytes

--- a/cborg/src/Codec/CBOR/FlatTerm.hs
+++ b/cborg/src/Codec/CBOR/FlatTerm.hs
@@ -564,7 +564,10 @@ tokenTypeOf :: TermToken -> TokenType
 tokenTypeOf (TkInt n)
     | n >= 0                = TypeUInt
     | otherwise             = TypeNInt
-tokenTypeOf TkInteger{}     = TypeInteger
+tokenTypeOf (TkInteger n)   -- See https://github.com/well-typed/cborg/issues/324
+  | n >= 0 && n <  2^64     = TypeUInt64
+  | n <  0 && n > -2^64     = TypeNInt64
+  | otherwise               = TypeInteger
 tokenTypeOf TkBytes{}       = TypeBytes
 tokenTypeOf TkBytesBegin{}  = TypeBytesIndef
 tokenTypeOf TkString{}      = TypeString

--- a/cborg/src/Codec/CBOR/FlatTerm.hs
+++ b/cborg/src/Codec/CBOR/FlatTerm.hs
@@ -562,28 +562,28 @@ fromFlatTerm decoder ft =
 -- | Map a 'TermToken' to the underlying CBOR 'TokenType'
 tokenTypeOf :: TermToken -> TokenType
 tokenTypeOf (TkInt n)
-    | n >= 0                = TypeUInt
-    | otherwise             = TypeNInt
+    | n >= 0                          = TypeUInt
+    | otherwise                       = TypeNInt
 tokenTypeOf (TkInteger n)   -- See https://github.com/well-typed/cborg/issues/324
-  | n >= 0 && n <  2^64     = TypeUInt64
-  | n <  0 && n > -2^64     = TypeNInt64
-  | otherwise               = TypeInteger
-tokenTypeOf TkBytes{}       = TypeBytes
-tokenTypeOf TkBytesBegin{}  = TypeBytesIndef
-tokenTypeOf TkString{}      = TypeString
-tokenTypeOf TkStringBegin{} = TypeStringIndef
-tokenTypeOf TkListLen{}     = TypeListLen
-tokenTypeOf TkListBegin{}   = TypeListLenIndef
-tokenTypeOf TkMapLen{}      = TypeMapLen
-tokenTypeOf TkMapBegin{}    = TypeMapLenIndef
-tokenTypeOf TkTag{}         = TypeTag
-tokenTypeOf TkBool{}        = TypeBool
-tokenTypeOf TkNull          = TypeNull
-tokenTypeOf TkBreak         = TypeBreak
-tokenTypeOf TkSimple{}      = TypeSimple
-tokenTypeOf TkFloat16{}     = TypeFloat16
-tokenTypeOf TkFloat32{}     = TypeFloat32
-tokenTypeOf TkFloat64{}     = TypeFloat64
+  | 0 <= n && n <= 0xffffffffffffffff = TypeUInt64
+  | -0xffffffffffffffff <= n && n < 0 = TypeNInt64
+  | otherwise                         = TypeInteger
+tokenTypeOf TkBytes{}                 = TypeBytes
+tokenTypeOf TkBytesBegin{}            = TypeBytesIndef
+tokenTypeOf TkString{}                = TypeString
+tokenTypeOf TkStringBegin{}           = TypeStringIndef
+tokenTypeOf TkListLen{}               = TypeListLen
+tokenTypeOf TkListBegin{}             = TypeListLenIndef
+tokenTypeOf TkMapLen{}                = TypeMapLen
+tokenTypeOf TkMapBegin{}              = TypeMapLenIndef
+tokenTypeOf TkTag{}                   = TypeTag
+tokenTypeOf TkBool{}                  = TypeBool
+tokenTypeOf TkNull                    = TypeNull
+tokenTypeOf TkBreak                   = TypeBreak
+tokenTypeOf TkSimple{}                = TypeSimple
+tokenTypeOf TkFloat16{}               = TypeFloat16
+tokenTypeOf TkFloat32{}               = TypeFloat32
+tokenTypeOf TkFloat64{}               = TypeFloat64
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Now `tokenTypeOf` distinguishes between:

- Unsigned 64 bit integers `(0     <= n < 2^64)`: `TypeUInt64`
- Negative 64 bit integers `(-2^64 < n  < 0   )`: `TypeNInt64`
- Integers outside the ranges above             : `TypeInteger`

Fixes https://github.com/well-typed/cborg/issues/324