### PR TITLE
Allow tar-0.6 in serialise benchmarks

### DIFF
--- a/serialise/serialise.cabal
+++ b/serialise/serialise.cabal
@@ -269,7 +269,7 @@ benchmark versus
     aeson                   >= 0.7     && < 2.3,
     cereal                  >= 0.5.2.0 && < 0.6,
     half                    >= 0.2.2.3 && < 0.4,
-    tar                     >= 0.4     && < 0.6,
+    tar                     >= 0.4     && < 0.7,
     zlib                    >= 0.5     && < 0.7,
     pretty                  >= 1.0     && < 1.2,
     criterion               >= 1.0     && < 1.7,


### PR DESCRIPTION
Closes #330. 

Benchmarks fail with `refined-containers/0.1.0.0/refined-containers.cabal: NoParse "tested-with" 29` anyway, but this not a fault of `tar`.

As a Hackage trustee I made a matching revision: https://hackage.haskell.org/package/serialise-0.2.6.1/revisions/