### PR TITLE
zlib 0.7

### DIFF
--- a/cborg-json/cborg-json.cabal
+++ b/cborg-json/cborg-json.cabal
@@ -65,7 +65,7 @@ benchmark bench
     bytestring >= 0.10.4  && < 0.13,
     criterion  >= 1.0     && < 1.7,
     deepseq    >= 1.0     && < 1.6,
-    zlib       >= 0.5     && < 0.7,
+    zlib       >= 0.5     && < 0.8,
     directory,
     process,
     aeson,

--- a/serialise/serialise.cabal
+++ b/serialise/serialise.cabal
@@ -270,7 +270,7 @@ benchmark versus
     cereal                  >= 0.5.2.0 && < 0.6,
     half                    >= 0.2.2.3 && < 0.4,
     tar                     >= 0.4     && < 0.7,
-    zlib                    >= 0.5     && < 0.7,
+    zlib                    >= 0.5     && < 0.8,
     pretty                  >= 1.0     && < 1.2,
     criterion               >= 1.0     && < 1.7,
     store                   >= 0.7.1   && < 0.8,

--- a/serialise/serialise.cabal
+++ b/serialise/serialise.cabal
@@ -269,7 +269,7 @@ benchmark versus
     aeson                   >= 0.7     && < 2.3,
     cereal                  >= 0.5.2.0 && < 0.6,
     half                    >= 0.2.2.3 && < 0.4,
-    tar                     >= 0.4     && < 0.6,
+    tar                     >= 0.4     && < 0.7,
     zlib                    >= 0.5     && < 0.7,
     pretty                  >= 1.0     && < 1.2,
     criterion               >= 1.0     && < 1.7,


### PR DESCRIPTION
- Includes #331: **Allow tar-0.6 in serialise benchmarks**
- Closes #332: **Allow zlib-0.7**
