### PR TITLE
Make compatible with new GHC JS backend

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -29,6 +29,11 @@ jobs:
       matrix:
         include:
           - compiler: ghc-9.8.1
+            compilerKind: ghcjs
+            compilerVersion: 9.8.1
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.8.1
             compilerKind: ghc
             compilerVersion: 9.8.1
             setup-method: ghcup

--- a/cborg/src/Codec/CBOR/Decoding.hs
+++ b/cborg/src/Codec/CBOR/Decoding.hs
@@ -157,7 +157,7 @@ data DecodeAction s a
     | ConsumeTag     (Word# -> ST s (DecodeAction s a))
 
 -- 64bit variants for 32bit machines
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
     | ConsumeWord64    (Word64# -> ST s (DecodeAction s a))
     | ConsumeNegWord64 (Word64# -> ST s (DecodeAction s a))
     | ConsumeInt64     (Int64#  -> ST s (DecodeAction s a))
@@ -188,7 +188,7 @@ data DecodeAction s a
 
     | PeekTokenType  (TokenType -> ST s (DecodeAction s a))
     | PeekAvailable  (Int#      -> ST s (DecodeAction s a))
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
     | PeekByteOffset (Int64#    -> ST s (DecodeAction s a))
 #else
     | PeekByteOffset (Int#      -> ST s (DecodeAction s a))
@@ -208,7 +208,7 @@ data DecodeAction s a
     | ConsumeMapLenCanonical  (Int#  -> ST s (DecodeAction s a))
     | ConsumeTagCanonical     (Word# -> ST s (DecodeAction s a))
 
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
     | ConsumeWord64Canonical    (Word64# -> ST s (DecodeAction s a))
     | ConsumeNegWord64Canonical (Word64# -> ST s (DecodeAction s a))
     | ConsumeInt64Canonical     (Int64#  -> ST s (DecodeAction s a))
@@ -420,7 +420,7 @@ decodeWord32 = Decoder (\k -> return (ConsumeWord32 (\w# -> k (toWord32 w#))))
 decodeWord64 :: Decoder s Word64
 {-# INLINE decodeWord64 #-}
 decodeWord64 =
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   Decoder (\k -> return (ConsumeWord (\w# -> k (toWord64 w#))))
 #else
   Decoder (\k -> return (ConsumeWord64 (\w64# -> k (toWord64 w64#))))
@@ -439,7 +439,7 @@ decodeNegWord = Decoder (\k -> return (ConsumeNegWord (\w# -> k (W# w#))))
 decodeNegWord64 :: Decoder s Word64
 {-# INLINE decodeNegWord64 #-}
 decodeNegWord64 =
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   Decoder (\k -> return (ConsumeNegWord (\w# -> k (toWord64 w#))))
 #else
   Decoder (\k -> return (ConsumeNegWord64 (\w64# -> k (toWord64 w64#))))
@@ -479,7 +479,7 @@ decodeInt32 = Decoder (\k -> return (ConsumeInt32 (\w# -> k (toInt32 w#))))
 decodeInt64 :: Decoder s Int64
 {-# INLINE decodeInt64 #-}
 decodeInt64 =
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   Decoder (\k -> return (ConsumeInt (\n# -> k (toInt64 n#))))
 #else
   Decoder (\k -> return (ConsumeInt64 (\n64# -> k (toInt64 n64#))))
@@ -519,7 +519,7 @@ decodeWord32Canonical = Decoder (\k -> return (ConsumeWord32Canonical (\w# -> k 
 decodeWord64Canonical :: Decoder s Word64
 {-# INLINE decodeWord64Canonical #-}
 decodeWord64Canonical =
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   Decoder (\k -> return (ConsumeWordCanonical (\w# -> k (toWord64 w#))))
 #else
   Decoder (\k -> return (ConsumeWord64Canonical (\w64# -> k (toWord64 w64#))))
@@ -538,7 +538,7 @@ decodeNegWordCanonical = Decoder (\k -> return (ConsumeNegWordCanonical (\w# -> 
 decodeNegWord64Canonical :: Decoder s Word64
 {-# INLINE decodeNegWord64Canonical #-}
 decodeNegWord64Canonical =
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   Decoder (\k -> return (ConsumeNegWordCanonical (\w# -> k (toWord64 w#))))
 #else
   Decoder (\k -> return (ConsumeNegWord64Canonical (\w64# -> k (toWord64 w64#))))
@@ -578,7 +578,7 @@ decodeInt32Canonical = Decoder (\k -> return (ConsumeInt32Canonical (\w# -> k (t
 decodeInt64Canonical :: Decoder s Int64
 {-# INLINE decodeInt64Canonical #-}
 decodeInt64Canonical =
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   Decoder (\k -> return (ConsumeIntCanonical (\n# -> k (toInt64 n#))))
 #else
   Decoder (\k -> return (ConsumeInt64Canonical (\n64# -> k (toInt64 n64#))))
@@ -752,7 +752,7 @@ decodeTag = Decoder (\k -> return (ConsumeTag (\w# -> k (W# w#))))
 decodeTag64 :: Decoder s Word64
 {-# INLINE decodeTag64 #-}
 decodeTag64 =
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   Decoder (\k -> return (ConsumeTag (\w# -> k (W64#
 #if MIN_VERSION_base(4,17,0)
     (wordToWord64# w#)
@@ -779,7 +779,7 @@ decodeTagCanonical = Decoder (\k -> return (ConsumeTagCanonical (\w# -> k (W# w#
 decodeTag64Canonical :: Decoder s Word64
 {-# INLINE decodeTag64Canonical #-}
 decodeTag64Canonical =
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   Decoder (\k -> return (ConsumeTagCanonical (\w# -> k (W64#
 #if MIN_VERSION_base(4,17,0)
     (wordToWord64# w#)

--- a/cborg/src/Codec/CBOR/FlatTerm.hs
+++ b/cborg/src/Codec/CBOR/FlatTerm.hs
@@ -385,7 +385,7 @@ fromFlatTerm decoder ft =
     go (TkTag     n : ts) (ConsumeTagCanonical     k)
         | n <= maxWord                       = k (unW# (fromIntegral n)) >>= go ts
 
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
     -- 64bit variants for 32bit machines
     go (TkInt       n : ts) (ConsumeWord64    k)
       | n >= 0                                   = k (unW64# (fromIntegral n)) >>= go ts
@@ -468,7 +468,7 @@ fromFlatTerm decoder ft =
     -- We don't have real bytes so we have to give these two operations
     -- different interpretations: remaining tokens and just 0 for offsets.
     go ts        (PeekAvailable k) = k (unI# (length ts)) >>= go ts
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
     go ts        (PeekByteOffset k)= k (unI64# 0) >>= go ts
 #else
     go ts        (PeekByteOffset k)= k 0# >>= go ts
@@ -529,7 +529,7 @@ fromFlatTerm decoder ft =
     go ts (ConsumeUtf8ByteArrayCanonical _) = unexpected "decodeUtf8ByteArrayCanonical" ts
     go ts (ConsumeSimpleCanonical  _)       = unexpected "decodeSimpleCanonical"        ts
 
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
     -- 64bit variants for 32bit machines
     go ts (ConsumeWord64    _) = unexpected "decodeWord64"    ts
     go ts (ConsumeNegWord64 _) = unexpected "decodeNegWord64" ts
@@ -744,7 +744,7 @@ unF#   (F#   f#) = f#
 unD# :: Double -> Double#
 unD#   (D#   f#) = f#
 
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
 unW64# :: Word64 -> Word64#
 unW64# (W64# w#) = w#
 


### PR DESCRIPTION
- We need to make a few changes to compile cborg with the new GHC Javascript backend.
- Tested with GHC 9.8.2.