### PR TITLE
serialise: Fix build with quickcheck-instances-0.3.32

### DIFF
--- a/serialise/tests/Tests/Orphanage.hs
+++ b/serialise/tests/Tests/Orphanage.hs
@@ -195,9 +195,11 @@ instance Arbitrary BSS.ShortByteString where
   arbitrary = BSS.pack <$> arbitrary
 #endif
 
+#if !MIN_VERSION_quickcheck_instances(0,3,32)
 instance (Vector.Primitive.Prim a, Arbitrary a
          ) => Arbitrary (Vector.Primitive.Vector a) where
     arbitrary = Vector.Primitive.fromList <$> arbitrary
+#endif
 
 #if MIN_VERSION_base(4,7,0) && !MIN_VERSION_QuickCheck(2,10,0)
 instance Arbitrary (Proxy a) where


### PR DESCRIPTION
Closes https://github.com/well-typed/cborg/issues/340

Fixes a build error due to overlapping instances:

```
[13 of 14] Compiling Tests.Serialise  ( tests/Tests/Serialise.hs, dist/build/tests/tests-tmp/Tests/Serialise.o )

tests/Tests/Serialise.hs:283:9: error: [GHC-43085]
    • Overlapping instances for Arbitrary (Vector.Primitive.Vector Int)
        arising from a use of ‘mkTest’
      Matching instances:
        instance (Vector.Primitive.Prim a, Arbitrary a) =>
                 Arbitrary (Vector.Primitive.Vector a)
          -- Defined in ‘Test.QuickCheck.Instances.Vector’
        instance (Vector.Primitive.Prim a, Arbitrary a) =>
                 Arbitrary (Vector.Primitive.Vector a)
          -- Defined at tests/Tests/Orphanage.hs:198:10
    • In the expression: mkTest (T :: T (Vector.Primitive.Vector Int))
      In the second argument of ‘testGroup’, namely
        ‘[mkTest (T :: T ()), mkTest (T :: T Bool), mkTest (T :: T Int),
          mkTest (T :: T Int8), ....]’
      In the expression:
        testGroup
          "Simple instance invariants"
          [mkTest (T :: T ()), mkTest (T :: T Bool), mkTest (T :: T Int),
           mkTest (T :: T Int8), ....]
    |
283 |       , mkTest (T :: T (Vector.Primitive.Vector Int))
    |         ^^^^^^
```