### PR TITLE
cborg-json: support indefinite length maps when decoding objects

### DIFF
--- a/cborg-json/cborg-json.cabal
+++ b/cborg-json/cborg-json.cabal
@@ -92,6 +92,7 @@ test-suite tests
     base-orphans,
     base16-bytestring       >= 1.0     && < 1.1,
     bytestring              >= 0.10.4  && < 0.13,
+    containers              >= 0.5     && < 0.8,
     cborg,
     cborg-json,
     aeson                   >= 0.7     && < 2.3,

--- a/cborg-json/tests/Main.hs
+++ b/cborg-json/tests/Main.hs
@@ -2,11 +2,16 @@
 
 module Main (main) where
 
+import           Codec.CBOR.Encoding
 import           Codec.CBOR.JSON
 import           Codec.CBOR.Read
-import           Data.Aeson (Value (String))
+import           Codec.CBOR.Write
+import           Data.Aeson (toJSON, Value (String))
 import qualified Data.ByteString.Base16 as HEX
 import           Data.ByteString.Lazy (fromStrict)
+import           Data.Map (Map)
+import qualified Data.Map as Map
+import qualified Data.Text as T
 import           Test.Tasty (TestTree, defaultMain, testGroup)
 import           Test.Tasty.HUnit (testCase, (@=?))
 
@@ -23,5 +28,17 @@ tests =
         [ testCase "decode variable ByteString as Base62Url String" $
             Right ("", String "MDEy") @=? deserialiseFromBytes (decodeValue True)
                                               (fromStrict . either error id $ HEX.decode "5803303132")
+        , testCase "decode Object encoded as indefinite length Map" $
+            Right ("", toJSON testMap) @=? deserialiseFromBytes (decodeValue True)
+                                              (toLazyByteString $ encodeMapIndef testMap)
         ]
     ]
+
+testMap :: Map T.Text Value
+testMap = Map.fromList $ [ (T.pack $ show n, toJSON (n :: Int)) | n <- [0..10]]
+
+encodeMapIndef :: Map T.Text Value -> Encoding
+encodeMapIndef vs =
+     encodeMapLenIndef
+  <> Map.foldrWithKey (\k v r -> encodeString k <> encodeValue v <> r) mempty vs
+  <> encodeBreak


### PR DESCRIPTION
The CBOR<->JSON encoding spec does not rule out indefinite length maps, and some other implementations can produce them at times (e.g. rust's serde with flatten attributes). 

- [x] Test case.