### PR TITLE
Use dupIO to avoid unwanted sharing when encoding (another take)

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -285,6 +285,16 @@ jobs:
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: prepare for constraint sets
+        run: |
+          rm -f cabal.project.local
+      - name: constraint set dupIO
+        run: |
+          $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='cborg +dupIO' all --dry-run
+          cabal-plan topo | sort
+          $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='cborg +dupIO' --dependencies-only -j2 all
+          $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='cborg +dupIO' all
+          $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='cborg +dupIO' all
       - name: save cache
         if: always()
         uses: actions/cache/save@v4

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,1 +1,6 @@
 branches: master
+
+constraint-set dupIO
+  constraints: cborg +dupIO
+  tests: True
+  run-tests: True

--- a/cborg/cborg.cabal
+++ b/cborg/cborg.cabal
@@ -59,6 +59,11 @@ flag optimize-gmp
   manual: False
   description: Use optimized code paths for integer-gmp
 
+flag dupIO
+  default: False
+  manual: True
+  description: Use dupIO to avoid unwanted sharing when encoding
+
 --------------------------------------------------------------------------------
 -- Library
 
@@ -100,6 +105,10 @@ library
 
   if !arch(x86_64) && impl(ghc <9.4)
     build-depends: ghc-prim
+
+  if flag(dupIO)
+    cpp-options:            -DDUPIO
+    build-depends: dupIO >= 0.1.0 && < 0.2
 
   if flag(optimize-gmp)
     cpp-options:            -DOPTIMIZE_GMP

--- a/cborg/src/Codec/CBOR/Write.hs
+++ b/cborg/src/Codec/CBOR/Write.hs
@@ -67,6 +67,10 @@ import qualified Codec.CBOR.ByteArray.Sliced           as BAS
 import           Codec.CBOR.Encoding
 import           Codec.CBOR.Magic
 
+#if defined(DUPIO)
+import qualified Data.Dup                              as Dup
+#endif
+
 --------------------------------------------------------------------------------
 
 -- | Turn an 'Encoding' into a lazy 'L.ByteString' in CBOR binary
@@ -102,7 +106,13 @@ buildStep vs1 k (BI.BufferRange op0 ope0) =
     go vs1 op0
   where
     go vs !op
-      | op `plusPtr` bound <= ope0 = case vs of
+      | op `plusPtr` bound <= ope0 = do
+#if defined(DUPIO)
+        dup_vs <- Dup.dupIO vs
+        case dup_vs of
+#else
+        case vs of
+#endif
           TkWord     x vs' -> PI.runB wordMP     x op >>= go vs'
           TkWord64   x vs' -> PI.runB word64MP   x op >>= go vs'
 

--- a/serialise/src/Codec/Serialise.hs
+++ b/serialise/src/Codec/Serialise.hs
@@ -153,7 +153,7 @@ hPutSerialise :: Serialise a
               => Handle       -- ^ The @'Handle'@ to write to.
               -> a            -- ^ The value to be serialised and written.
               -> IO ()
-hPutSerialise hnd x = BS.hPut hnd (serialise x)
+hPutSerialise hnd x = BS.hPutBuilder hnd (CBOR.Write.toBuilder (encode x))
 
 -- | Serialise a @'BS.ByteString'@ and write it directly to the
 -- specified file.


### PR DESCRIPTION
Rebased https://github.com/well-typed/cborg/pull/321 

@adamgundry asked "This raises the question of how to test it in CI..", `haskell-ci` has support for that.

I won't merge this as this adds a non-trivial dependency. Currently GHC-9.12 is excluded CI as `dupIO` doesn't allow it.