### PR TITLE
Add simple mac and win CI

### DIFF
--- a/.github/workflows/macwin.yml
+++ b/.github/workflows/macwin.yml
@@ -1,0 +1,57 @@
+name: Simple
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  native:
+    name: "MacWin: GHC ${{ matrix.ghc }} on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest]
+        # older GHCs don't work well on macos-latest (i.e. arm)
+        ghc: ['9.10','9.12']
+      fail-fast: false
+    steps:
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - name: Checkout
+        uses: actions/checkout@v3.0.2
+
+      - name: Set up Haskell
+        id: setup-haskell
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: '3.14.2.0'
+
+      - name: Dependency resolution
+        run: cabal build all --enable-tests --dry-run
+
+      - name: Restore cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.setup-haskell.outputs.cabal-store }}
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dist-newstyle/cache/plan.json') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
+
+      - name: Build
+        run: cabal build all --enable-tests
+
+      - name: Test
+        run: cabal test all --enable-tests --test-show-details=direct
+
+      - name: Save cache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.setup-haskell.outputs.cabal-store }}
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dist-newstyle/cache/plan.json') }}


### PR DESCRIPTION
... especially mac is now aarch64, so it's good to test. It doesn't have cheap unaligned reads, AFAIK, at least cbor.h enables them for x86/64 archs only.