### PR TITLE
Serialise UTCTime as epoch-based date-time

### DIFF
--- a/serialise/ChangeLog.md
+++ b/serialise/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## 0.3.0.0  -- 2025-mm-dd
 
+* Serialize UTCTime using epoch date time (previously non-standard encoding)
+* Add `extendedEncodeUTCTime` for serialising 'UTCTime' using extended time format ([rfc9581](https://www.ietf.org/rfc/rfc9581.html))
 * Generic encoding of empty data-types will not succeed anymore.
   Previously they were encoded as null.
   The new behaviour is consistent with `Serialise Void` instance.

--- a/serialise/serialise.cabal
+++ b/serialise/serialise.cabal
@@ -86,7 +86,7 @@ library
 --------------------------------------------------------------------------------
 -- Tests
 
-test-suite tests
+test-suite serialise-tests
   type:              exitcode-stdio-1.0
   hs-source-dirs:    tests
   main-is:           Main.hs


### PR DESCRIPTION
- add extenedEncodeUTCTime for RFC9581 encoding
- Fix decoding to use 1001 tag