### PR TITLE
Disable threading for `wasm32` compilation

### DIFF
--- a/cborg-json/cborg-json.cabal
+++ b/cborg-json/cborg-json.cabal
@@ -78,9 +78,13 @@ test-suite tests
   main-is:           Main.hs
 
   default-language:  Haskell2010
-  ghc-options:
-    -Wall -fno-warn-orphans
-    -threaded -rtsopts "-with-rtsopts=-N2"
+  if arch(wasm32)
+    ghc-options:
+      -Wall -fno-warn-orphans
+  else
+    ghc-options:
+      -Wall -fno-warn-orphans
+      -threaded -rtsopts "-with-rtsopts=-N2"
 
   other-modules:
 

--- a/cborg/cborg.cabal
+++ b/cborg/cborg.cabal
@@ -119,9 +119,13 @@ test-suite cborg-tests
   main-is:           Main.hs
 
   default-language:  Haskell2010
-  ghc-options:
-    -Wall -Wno-orphans
-    -threaded -rtsopts "-with-rtsopts=-N2"
+  if arch(wasm32)
+    ghc-options:
+      -Wall -Wno-orphans
+  else
+    ghc-options:
+      -Wall -Wno-orphans
+      -threaded -rtsopts "-with-rtsopts=-N2"
 
   other-modules:
     Tests.UnitTests

--- a/serialise/serialise.cabal
+++ b/serialise/serialise.cabal
@@ -93,9 +93,13 @@ test-suite tests
   main-is:           Main.hs
 
   default-language:  Haskell2010
-  ghc-options:
-    -Wall -fno-warn-orphans
-    -threaded -rtsopts "-with-rtsopts=-N2"
+  if arch(wasm32)
+    ghc-options:
+      -Wall -fno-warn-orphans
+  else
+    ghc-options:
+      -Wall -fno-warn-orphans
+      -threaded -rtsopts "-with-rtsopts=-N2"
 
   other-modules:
     Tests.IO


### PR DESCRIPTION
When compiling the projects in the repo with `wasm32-wasi` compiler I get the following error:

```
Starting     criterion-1.6.4.1 (lib)
wasm-ld: error: unable to find library -lHSrts-1.0.2_thr
wasm32-wasi-clang: error: linker command failed with exit code 1 (use -v to see invocation)
wasm32-wasi-ghc: `wasm32-wasi-clang' failed in phase `Linker'. (Exit code: 1)
wasm-ld: error: unable to find library -lHSrts-1.0.2_thr
wasm32-wasi-clang: error: linker command failed with exit code 1 (use -v to see invocation)
wasm32-wasi-ghc: `wasm32-wasi-clang' failed in phase `Linker'. (Exit code: 1)
```

To address the issue, this PR disables the threading flags when compiling to `wasm32`. This change doesn't affect compilation to other targets since it is conditional.