### PR TITLE
Make compatible with new GHC JS backend, v2

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -279,9 +279,11 @@ jobs:
         run: |
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --write-ghc-environment-files=always
       - name: tests
+        if: matrix.compilerKind != "ghcjs"
         run: |
           $CABAL v2-test $ARG_COMPILER $ARG_TESTS $ARG_BENCH all --test-show-details=direct
       - name: cabal check
+        if: matrix.compilerKind != "ghcjs"
         run: |
           cd ${PKGDIR_cborg} || false
           ${CABAL} -vnormal check
@@ -294,6 +296,7 @@ jobs:
           cd ${PKGDIR_cborg_json} || false
           ${CABAL} -vnormal check
       - name: haddock
+        if: matrix.compilerKind != "ghcjs"
         run: |
           $CABAL v2-haddock --disable-documentation --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -37,6 +37,11 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.12.12
+            compilerKind: ghcjs
+            compilerVersion: 9.12.12
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.14.1
             compilerKind: ghc
             compilerVersion: 9.14.1

--- a/cborg/src/Codec/CBOR/Decoding.hs
+++ b/cborg/src/Codec/CBOR/Decoding.hs
@@ -164,7 +164,7 @@ data DecodeAction s a
     | ConsumeTag     (Word# -> ST s (DecodeAction s a))
 
 -- 64bit variants for 32bit machines
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
     | ConsumeWord64    (Word64# -> ST s (DecodeAction s a))
     | ConsumeNegWord64 (Word64# -> ST s (DecodeAction s a))
     | ConsumeInt64     (Int64#  -> ST s (DecodeAction s a))
@@ -195,7 +195,7 @@ data DecodeAction s a
 
     | PeekTokenType  (TokenType -> ST s (DecodeAction s a))
     | PeekAvailable  (Int#      -> ST s (DecodeAction s a))
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
     | PeekByteOffset (Int64#    -> ST s (DecodeAction s a))
 #else
     | PeekByteOffset (Int#      -> ST s (DecodeAction s a))
@@ -218,7 +218,7 @@ data DecodeAction s a
     | ConsumeMapLenCanonical  (Int#  -> ST s (DecodeAction s a))
     | ConsumeTagCanonical     (Word# -> ST s (DecodeAction s a))
 
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
     | ConsumeWord64Canonical    (Word64# -> ST s (DecodeAction s a))
     | ConsumeNegWord64Canonical (Word64# -> ST s (DecodeAction s a))
     | ConsumeInt64Canonical     (Int64#  -> ST s (DecodeAction s a))
@@ -324,7 +324,7 @@ toInt32  :: Int# -> Int32
 toWord8  :: Word# -> Word8
 toWord16 :: Word# -> Word16
 toWord32 :: Word# -> Word32
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS) 
 toInt64  :: Int# -> Int64
 toWord64 :: Word# -> Word64
 #else
@@ -338,7 +338,7 @@ toInt32  n = I32# (intToInt32# n)
 toWord8  n = W8#  (wordToWord8# n)
 toWord16 n = W16# (wordToWord16# n)
 toWord32 n = W32# (wordToWord32# n)
-#if MIN_VERSION_base(4,17,0) && defined(ARCH_64bit)
+#if MIN_VERSION_base(4,17,0) && (defined(ARCH_64bit) || defined(ghcjs_HOST_OS))
 toInt64  n = I64# (intToInt64# n)
 toWord64 n = W64# (wordToWord64# n)
 #else
@@ -426,7 +426,7 @@ decodeWord32 = Decoder (\k -> return (ConsumeWord32 (\w# -> k (toWord32 w#))))
 decodeWord64 :: Decoder s Word64
 {-# INLINE decodeWord64 #-}
 decodeWord64 =
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   Decoder (\k -> return (ConsumeWord (\w# -> k (toWord64 w#))))
 #else
   Decoder (\k -> return (ConsumeWord64 (\w64# -> k (toWord64 w64#))))
@@ -445,7 +445,7 @@ decodeNegWord = Decoder (\k -> return (ConsumeNegWord (\w# -> k (W# w#))))
 decodeNegWord64 :: Decoder s Word64
 {-# INLINE decodeNegWord64 #-}
 decodeNegWord64 =
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   Decoder (\k -> return (ConsumeNegWord (\w# -> k (toWord64 w#))))
 #else
   Decoder (\k -> return (ConsumeNegWord64 (\w64# -> k (toWord64 w64#))))
@@ -485,7 +485,7 @@ decodeInt32 = Decoder (\k -> return (ConsumeInt32 (\w# -> k (toInt32 w#))))
 decodeInt64 :: Decoder s Int64
 {-# INLINE decodeInt64 #-}
 decodeInt64 =
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   Decoder (\k -> return (ConsumeInt (\n# -> k (toInt64 n#))))
 #else
   Decoder (\k -> return (ConsumeInt64 (\n64# -> k (toInt64 n64#))))
@@ -525,7 +525,7 @@ decodeWord32Canonical = Decoder (\k -> return (ConsumeWord32Canonical (\w# -> k 
 decodeWord64Canonical :: Decoder s Word64
 {-# INLINE decodeWord64Canonical #-}
 decodeWord64Canonical =
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   Decoder (\k -> return (ConsumeWordCanonical (\w# -> k (toWord64 w#))))
 #else
   Decoder (\k -> return (ConsumeWord64Canonical (\w64# -> k (toWord64 w64#))))
@@ -544,7 +544,7 @@ decodeNegWordCanonical = Decoder (\k -> return (ConsumeNegWordCanonical (\w# -> 
 decodeNegWord64Canonical :: Decoder s Word64
 {-# INLINE decodeNegWord64Canonical #-}
 decodeNegWord64Canonical =
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   Decoder (\k -> return (ConsumeNegWordCanonical (\w# -> k (toWord64 w#))))
 #else
   Decoder (\k -> return (ConsumeNegWord64Canonical (\w64# -> k (toWord64 w64#))))
@@ -584,7 +584,7 @@ decodeInt32Canonical = Decoder (\k -> return (ConsumeInt32Canonical (\w# -> k (t
 decodeInt64Canonical :: Decoder s Int64
 {-# INLINE decodeInt64Canonical #-}
 decodeInt64Canonical =
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   Decoder (\k -> return (ConsumeIntCanonical (\n# -> k (toInt64 n#))))
 #else
   Decoder (\k -> return (ConsumeInt64Canonical (\n64# -> k (toInt64 n64#))))
@@ -758,7 +758,7 @@ decodeTag = Decoder (\k -> return (ConsumeTag (\w# -> k (W# w#))))
 decodeTag64 :: Decoder s Word64
 {-# INLINE decodeTag64 #-}
 decodeTag64 =
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   Decoder (\k -> return (ConsumeTag (\w# -> k (W64#
 #if MIN_VERSION_base(4,17,0)
     (wordToWord64# w#)
@@ -785,7 +785,7 @@ decodeTagCanonical = Decoder (\k -> return (ConsumeTagCanonical (\w# -> k (W# w#
 decodeTag64Canonical :: Decoder s Word64
 {-# INLINE decodeTag64Canonical #-}
 decodeTag64Canonical =
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   Decoder (\k -> return (ConsumeTagCanonical (\w# -> k (W64#
 #if MIN_VERSION_base(4,17,0)
     (wordToWord64# w#)
@@ -1061,7 +1061,7 @@ type ByteOffset = Int64
 -- @since 0.2.2.0
 peekByteOffset :: Decoder s ByteOffset
 peekByteOffset = Decoder (\k -> return (PeekByteOffset (\off# -> k (I64#
-#if MIN_VERSION_base(4,17,0) && !defined(ARCH_32bit)
+#if MIN_VERSION_base(4,17,0) && (defined(ARCH_64bit) || defined(ghcjs_HOST_OS))
         (intToInt64# off#)
 #else
         off#

--- a/cborg/src/Codec/CBOR/FlatTerm.hs
+++ b/cborg/src/Codec/CBOR/FlatTerm.hs
@@ -50,7 +50,7 @@ import qualified Codec.CBOR.ByteArray        as BA
 import qualified Codec.CBOR.ByteArray.Sliced as BAS
 
 import           Data.Int
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
 import           GHC.Int   (Int64(I64#))
 import           GHC.Word  (Word64(W64#))
 import           GHC.Exts  (Word64#, Int64#)
@@ -386,7 +386,7 @@ fromFlatTerm decoder ft =
     go (TkTag     n : ts) (ConsumeTagCanonical     k)
         | n <= maxWord                       = k (unW# (fromIntegral n)) >>= go ts
 
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
     -- 64bit variants for 32bit machines
     go (TkInt       n : ts) (ConsumeWord64    k)
       | n >= 0                                   = k (unW64# (fromIntegral n)) >>= go ts
@@ -470,7 +470,7 @@ fromFlatTerm decoder ft =
     -- different interpretations: remaining tokens and just 0 for offsets, and
     -- empty for byte spans.
     go ts        (PeekAvailable k) = k (unI# (length ts)) >>= go ts
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
     go ts        (PeekByteOffset k)= k (unI64# 0) >>= go ts
 #else
     go ts        (PeekByteOffset k)= k 0# >>= go ts
@@ -534,7 +534,7 @@ fromFlatTerm decoder ft =
     go ts (ConsumeUtf8ByteArrayCanonical _) = unexpected "decodeUtf8ByteArrayCanonical" ts
     go ts (ConsumeSimpleCanonical  _)       = unexpected "decodeSimpleCanonical"        ts
 
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
     -- 64bit variants for 32bit machines
     go ts (ConsumeWord64    _) = unexpected "decodeWord64"    ts
     go ts (ConsumeNegWord64 _) = unexpected "decodeNegWord64" ts
@@ -749,7 +749,7 @@ unF#   (F#   f#) = f#
 unD# :: Double -> Double#
 unD#   (D#   f#) = f#
 
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
 unW64# :: Word64 -> Word64#
 unW64# (W64# w#) = w#
 

--- a/cborg/src/Codec/CBOR/Magic.hs
+++ b/cborg/src/Codec/CBOR/Magic.hs
@@ -4,6 +4,11 @@
 {-# LANGUAGE UnboxedTuples            #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE ScopedTypeVariables      #-}
+#if defined(ghcjs_HOST_OS)
+-- when using javascript backend Word is a 64 bit type, but ghc emits
+-- `-Woverflowed-literals` warning when using `0x80000000##`.
+{-# OPTIONS_GHC -Wno-overflowed-literals #-}
+#endif
 
 #include "cbor.h"
 
@@ -60,7 +65,7 @@ module Codec.CBOR.Magic
   , intToWord64       -- :: Int    -> Word64
   , int64ToWord64     -- :: Int64  -> Word64
 
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
   , word8ToInt64      -- :: Word8  -> Int64
   , word16ToInt64     -- :: Word16 -> Int64
   , word32ToInt64     -- :: Word32 -> Int64
@@ -123,7 +128,6 @@ import           Data.Bits ((.|.), unsafeShiftL)
 import           GHC.IntWord64 (wordToWord64#, word64ToWord#,
                                 intToInt64#, int64ToInt#,
                                 leWord64#, ltWord64#, word64ToInt64#)
-
 #endif
 
 --------------------------------------------------------------------------------
@@ -164,7 +168,7 @@ grabWord32 (Ptr ip#) = W32# (wordToWord32# (byteSwap32# (word32ToWord# (indexWor
 grabWord16 (Ptr ip#) = W16# (narrow16Word# (byteSwap16# (indexWord16OffAddr# ip# 0#)))
 grabWord32 (Ptr ip#) = W32# (narrow32Word# (byteSwap32# (indexWord32OffAddr# ip# 0#)))
 #endif
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
 #if MIN_VERSION_base(4,17,0)
 grabWord64 (Ptr ip#) = W64# (wordToWord64# (byteSwap# (word64ToWord# (indexWord64OffAddr# ip# 0#))))
 #else
@@ -362,7 +366,7 @@ wordToFloat64 = GHC.Float.castWord64ToDouble
 word8ToWord  :: Word8  -> Word
 word16ToWord :: Word16 -> Word
 word32ToWord :: Word32 -> Word
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
 word64ToWord :: Word64 -> Word
 #else
 word64ToWord :: Word64 -> Maybe Word
@@ -370,14 +374,14 @@ word64ToWord :: Word64 -> Maybe Word
 
 word8ToInt  :: Word8  -> Int
 word16ToInt :: Word16 -> Int
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
 word32ToInt :: Word32 -> Int
 #else
 word32ToInt :: Word32 -> Maybe Int
 #endif
 word64ToInt :: Word64 -> Maybe Int
 
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
 word8ToInt64  :: Word8  -> Int64
 word16ToInt64 :: Word16 -> Int64
 word32ToInt64 :: Word32 -> Int64
@@ -412,7 +416,7 @@ int64ToWord64 = fromIntegral
 word8ToWord  (W8#  w#) = W# (word8ToWord# w#)
 word16ToWord (W16# w#) = W# (word16ToWord# w#)
 word32ToWord (W32# w#) = W# (word32ToWord# w#)
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
 #if MIN_VERSION_base(4,17,0)
 word64ToWord (W64# w#) = W# (word64ToWord# w#)
 #else
@@ -428,7 +432,7 @@ word64ToWord (W64# w64#) =
 word8ToWord  (W8#  w#) = W# w#
 word16ToWord (W16# w#) = W# w#
 word32ToWord (W32# w#) = W# w#
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
 word64ToWord (W64# w#) = W# w#
 #else
 word64ToWord (W64# w64#) =
@@ -446,7 +450,7 @@ word64ToWord (W64# w64#) =
 #if MIN_VERSION_base(4,16,0)
 word8ToInt  (W8#  w#) = I# (word2Int# (word8ToWord# w#))
 word16ToInt (W16# w#) = I# (word2Int# (word16ToWord# w#))
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
 word32ToInt (W32# w#) = I# (word2Int# (word32ToWord# w#))
 #else
 word32ToInt (W32# w#) =
@@ -458,7 +462,7 @@ word32ToInt (W32# w#) =
 word8ToInt  (W8#  w#) = I# (word2Int# w#)
 word16ToInt (W16# w#) = I# (word2Int# w#)
 
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
 word32ToInt (W32# w#) = I# (word2Int# w#)
 #else
 word32ToInt (W32# w#) =
@@ -468,7 +472,7 @@ word32ToInt (W32# w#) =
 #endif
 #endif
 
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
 word64ToInt (W64# w#) =
 #if MIN_VERSION_base(4,17,0)
   case isTrue# (word64ToWord# w# `ltWord#` 0x8000000000000000##) of
@@ -495,7 +499,7 @@ word64ToInt (W64# w#) =
 {-# INLINE word32ToInt #-}
 {-# INLINE word64ToInt #-}
 
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
 #if MIN_VERSION_base(4,16,0)
 word8ToInt64  (W8#  w#) = I64# (intToInt64# (word2Int# (word8ToWord# w#)))
 word16ToInt64 (W16# w#) = I64# (intToInt64# (word2Int# (word16ToWord# w#)))

--- a/cborg/src/Codec/CBOR/Read.hs
+++ b/cborg/src/Codec/CBOR/Read.hs
@@ -240,7 +240,7 @@ data SlowPath s a
    | SlowConsumeTokenByteArray     {-# UNPACK #-} !ByteString (BA.ByteArray -> ST s (DecodeAction s a)) {-# UNPACK #-} !Int
    | SlowConsumeTokenString        {-# UNPACK #-} !ByteString (T.Text       -> ST s (DecodeAction s a)) {-# UNPACK #-} !Int
    | SlowConsumeTokenUtf8ByteArray {-# UNPACK #-} !ByteString (BA.ByteArray -> ST s (DecodeAction s a)) {-# UNPACK #-} !Int
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
    | SlowPeekByteOffset            {-# UNPACK #-} !ByteString (Int64#       -> ST s (DecodeAction s a))
 #else
    | SlowPeekByteOffset            {-# UNPACK #-} !ByteString (Int#         -> ST s (DecodeAction s a))
@@ -289,7 +289,7 @@ go_fast !bs da@(ConsumeWord32 k) =
     case tryConsumeWord (BS.unsafeHead bs) bs of
       DecodeFailure           -> go_fast_end bs da
       DecodedToken sz (W# w#) ->
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
                                  k w# >>= go_fast (BS.unsafeDrop sz bs)
 #else
         case gtWord# w# 0xffffffff## of
@@ -327,7 +327,7 @@ go_fast !bs da@(ConsumeInt32 k) =
     case tryConsumeInt (BS.unsafeHead bs) bs of
       DecodeFailure           -> go_fast_end bs da
       DecodedToken sz (I# n#) ->
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
                                  k n# >>= go_fast (BS.unsafeDrop sz bs)
 #else
         case (n# ># 0x7fffffff#) `orI#` (n# <# -0x80000000#) of
@@ -383,7 +383,7 @@ go_fast !bs da@(ConsumeWord32Canonical k) =
   where
     w_out_of_range :: Word# -> Int#
     w_out_of_range _w# =
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
       0#
 #else
       gtWord# _w# 0xffffffff##
@@ -429,7 +429,7 @@ go_fast !bs da@(ConsumeInt32Canonical k) =
   where
     n_out_of_range :: Int# -> Int#
     n_out_of_range _n# =
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
       0#
 #else
       (_n# ># 0x7fffffff#) `orI#` (_n# <# -0x80000000#)
@@ -458,7 +458,7 @@ go_fast !bs da@(ConsumeTagCanonical k) =
         | isWordCanonical sz w  -> k w# >>= go_fast (BS.unsafeDrop sz bs)
         | otherwise             -> go_fast_end bs da
 
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
 go_fast !bs da@(ConsumeWord64 k) =
   case tryConsumeWord64 (BS.unsafeHead bs) bs of
     DecodeFailure             -> go_fast_end bs da
@@ -776,7 +776,7 @@ go_fast_end !bs (ConsumeWord32 k) =
     case tryConsumeWord (BS.unsafeHead bs) bs of
       DecodeFailure           -> return $! SlowFail bs "expected word32"
       DecodedToken sz (W# w#) ->
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
                                  k w# >>= go_fast_end (BS.unsafeDrop sz bs)
 #else
         case gtWord# w# 0xffffffff## of
@@ -814,7 +814,7 @@ go_fast_end !bs (ConsumeInt32 k) =
     case tryConsumeInt (BS.unsafeHead bs) bs of
       DecodeFailure           -> return $! SlowFail bs "expected int32"
       DecodedToken sz (I# n#) ->
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
                                  k n# >>= go_fast_end (BS.unsafeDrop sz bs)
 #else
         case (n# ># 0x7fffffff#) `orI#` (n# <# -0x80000000#) of
@@ -870,7 +870,7 @@ go_fast_end !bs (ConsumeWord32Canonical k) =
   where
     w_out_of_range :: Word# -> Int#
     w_out_of_range _w# =
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
       0#
 #else
       gtWord# _w# 0xffffffff##
@@ -919,7 +919,7 @@ go_fast_end !bs (ConsumeInt32Canonical k) =
   where
     n_out_of_range :: Int# -> Int#
     n_out_of_range _n# =
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
       0#
 #else
       (_n# ># 0x7fffffff#) `orI#` (_n# <# -0x80000000#)
@@ -948,7 +948,7 @@ go_fast_end !bs (ConsumeTagCanonical k) =
         | isWordCanonical sz w  -> k w# >>= go_fast_end (BS.unsafeDrop sz bs)
         | otherwise             -> return $! SlowFail bs "non-canonical tag"
 
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
 go_fast_end !bs (ConsumeWord64 k) =
   case tryConsumeWord64 (BS.unsafeHead bs) bs of
     DecodeFailure             -> return $! SlowFail bs "expected word64"
@@ -1336,7 +1336,7 @@ go_slow da bs !offset !marks = do
 
     SlowPeekByteOffset bs' k ->
       lift
-#if MIN_VERSION_base(4,17,0) && !defined(ARCH_32bit)
+#if MIN_VERSION_base(4,17,0) && (defined(ARCH_64bit) || defined(ghcjs_HOST_OS))
         (k (int64ToInt# off#))
 #else
         (k off#)
@@ -1463,7 +1463,7 @@ go_slow_overlapped da sz bs_cur bs_next !offset !marks =
       SlowPeekByteOffset bs_empty k ->
         assert (BS.null bs_empty) $ do
         lift
-#if MIN_VERSION_base(4,17,0) && !defined(ARCH_32bit)
+#if MIN_VERSION_base(4,17,0) && (defined(ARCH_64bit) || defined(ghcjs_HOST_OS))
           (k (int64ToInt# off#))
 #else
           (k off#)
@@ -1661,7 +1661,7 @@ isIntCanonical sz i
   where
     w = intToWord i
 
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
 {-# INLINE isWord64Canonical #-}
 isWord64Canonical :: Int -> Word64 -> Bool
 isWord64Canonical sz w
@@ -1722,7 +1722,7 @@ tryConsumeWord hdr !bs = case word8ToWord hdr of
   0x18 -> DecodedToken 2 $! word8ToWord  (eatTailWord8 bs)
   0x19 -> DecodedToken 3 $! word16ToWord (eatTailWord16 bs)
   0x1a -> DecodedToken 5 $! word32ToWord (eatTailWord32 bs)
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   0x1b -> DecodedToken 9 $! word64ToWord (eatTailWord64 bs)
 #else
   0x1b -> case word64ToWord (eatTailWord64 bs) of
@@ -1763,7 +1763,7 @@ tryConsumeNegWord hdr !bs = case word8ToWord hdr of
   0x38 -> DecodedToken 2 $! (word8ToWord  (eatTailWord8 bs))
   0x39 -> DecodedToken 3 $! (word16ToWord (eatTailWord16 bs))
   0x3a -> DecodedToken 5 $! (word32ToWord (eatTailWord32 bs))
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   0x3b -> DecodedToken 9 $! (word64ToWord (eatTailWord64 bs))
 #else
   0x3b -> case word64ToWord (eatTailWord64 bs) of
@@ -1803,7 +1803,7 @@ tryConsumeInt hdr !bs = case word8ToWord hdr of
   0x17 -> DecodedToken 1 23
   0x18 -> DecodedToken 2 $! (word8ToInt  (eatTailWord8 bs))
   0x19 -> DecodedToken 3 $! (word16ToInt (eatTailWord16 bs))
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   0x1a -> DecodedToken 5 $! (word32ToInt (eatTailWord32 bs))
 #else
   0x1a -> case word32ToInt (eatTailWord32 bs) of
@@ -1841,7 +1841,7 @@ tryConsumeInt hdr !bs = case word8ToWord hdr of
   0x37 -> DecodedToken 1 (-24)
   0x38 -> DecodedToken 2 $! (-1 - word8ToInt  (eatTailWord8 bs))
   0x39 -> DecodedToken 3 $! (-1 - word16ToInt (eatTailWord16 bs))
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   0x3a -> DecodedToken 5 $! (-1 - word32ToInt (eatTailWord32 bs))
 #else
   0x3a -> case word32ToInt (eatTailWord32 bs) of
@@ -1895,7 +1895,7 @@ tryConsumeInteger hdr !bs = case word8ToWord hdr of
           in DecodedToken sz (BigIntToken (isWordCanonical sz (word32ToWord w))   $! toInteger w)
   0x1b -> let !w = eatTailWord64 bs
               sz = 9
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
           in DecodedToken sz (BigIntToken (isWord64Canonical sz w) $! toInteger w)
 #else
           in DecodedToken sz (BigIntToken (isWordCanonical sz (word64ToWord w))   $! toInteger w)
@@ -1937,7 +1937,7 @@ tryConsumeInteger hdr !bs = case word8ToWord hdr of
           in DecodedToken sz (BigIntToken (isWordCanonical sz (word32ToWord w))   $! (-1 - toInteger w))
   0x3b -> let !w = eatTailWord64 bs
               sz = 9
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
           in DecodedToken sz (BigIntToken (isWord64Canonical sz w) $! (-1 - toInteger w))
 #else
           in DecodedToken sz (BigIntToken (isWordCanonical sz (word64ToWord w))   $! (-1 - toInteger w))
@@ -2051,7 +2051,7 @@ tryConsumeListLen hdr !bs = case word8ToWord hdr of
   0x97 -> DecodedToken 1 23
   0x98 -> DecodedToken 2 (word8ToInt  (eatTailWord8 bs))
   0x99 -> DecodedToken 3 (word16ToInt (eatTailWord16 bs))
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   0x9a -> DecodedToken 5 (word32ToInt (eatTailWord32 bs))
 #else
   0x9a -> case word32ToInt (eatTailWord32 bs) of
@@ -2094,7 +2094,7 @@ tryConsumeMapLen hdr !bs = case word8ToWord hdr of
   0xb7 -> DecodedToken 1 23
   0xb8 -> DecodedToken 2 $! (word8ToInt  (eatTailWord8 bs))
   0xb9 -> DecodedToken 3 $! (word16ToInt (eatTailWord16 bs))
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   0xba -> DecodedToken 5 $! (word32ToInt (eatTailWord32 bs))
 #else
   0xba -> case word32ToInt (eatTailWord32 bs) of
@@ -2152,7 +2152,7 @@ tryConsumeListLenOrIndef hdr !bs = case word8ToWord hdr of
   0x97 -> DecodedToken 1 23
   0x98 -> DecodedToken 2 $! (word8ToInt  (eatTailWord8 bs))
   0x99 -> DecodedToken 3 $! (word16ToInt (eatTailWord16 bs))
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   0x9a -> DecodedToken 5 $! (word32ToInt (eatTailWord32 bs))
 #else
   0x9a -> case word32ToInt (eatTailWord32 bs) of
@@ -2197,7 +2197,7 @@ tryConsumeMapLenOrIndef hdr !bs = case word8ToWord hdr of
   0xb7 -> DecodedToken 1 23
   0xb8 -> DecodedToken 2 $! (word8ToInt  (eatTailWord8 bs))
   0xb9 -> DecodedToken 3 $! (word16ToInt (eatTailWord16 bs))
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   0xba -> DecodedToken 5 $! (word32ToInt (eatTailWord32 bs))
 #else
   0xba -> case word32ToInt (eatTailWord32 bs) of
@@ -2243,7 +2243,7 @@ tryConsumeTag hdr !bs = case word8ToWord hdr of
   0xd8 -> DecodedToken 2 $! (word8ToWord  (eatTailWord8 bs))
   0xd9 -> DecodedToken 3 $! (word16ToWord (eatTailWord16 bs))
   0xda -> DecodedToken 5 $! (word32ToWord (eatTailWord32 bs))
-#if defined(ARCH_64bit)
+#if defined(ARCH_64bit) || defined(ghcjs_HOST_OS)
   0xdb -> DecodedToken 9 $! (word64ToWord (eatTailWord64 bs))
 #else
   0xdb -> case word64ToWord (eatTailWord64 bs) of
@@ -2256,7 +2256,7 @@ tryConsumeTag hdr !bs = case word8ToWord hdr of
 -- 64-on-32 bit code paths
 --
 
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
 tryConsumeWord64 :: Word8 -> ByteString -> DecodedToken Word64
 tryConsumeWord64 hdr !bs = case word8ToWord hdr of
   -- Positive integers (type 0)
@@ -2633,7 +2633,7 @@ readBytes16 bs
     lengthCanonical = isIntCanonical hdrsz n
 
 readBytes32 bs = case word32ToInt (eatTailWord32 bs) of
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
     Just n
 #else
     n
@@ -2645,7 +2645,7 @@ readBytes32 bs = case word32ToInt (eatTailWord32 bs) of
       -- if n > bound then slow path, multi-chunk
       | otherwise -> DecodedToken hdrsz $ TooLong (isIntCanonical hdrsz n) n
 
-#if defined(ARCH_32bit)
+#if defined(ARCH_32bit) && !defined(ghcjs_HOST_OS)
     Nothing       -> DecodeFailure
 #endif
   where


### PR DESCRIPTION
I updated #335 to `master`, resolved conflicts and hopefully fixed CI :crossed_fingers:.

The javascript backend is not yet ready to build `haddocks` or run `cborg-tests`.  The closest I got was:
```
cabal run cborg:cborg-tests -- --color=never < /dev/null
CBOR
uncaught exception in Haskell thread: ReferenceError: h$splitmix_init is not defined
ReferenceError: h$splitmix_init is not defined
    at h$$e5c66042 (/home/coot/src/haskell/cborg/dist-newstyle/build/javascript-ghcjs/ghc-9.12.2/cborg-0.2.10.0/t/cborg-tests/build/cborg-tests/cborg-tests)
    at h$runThreadSlice (/home/coot/src/haskell/cborg/dist-newstyle/build/javascript-ghcjs/ghc-9.12.2/cborg-0.2.10.0/t/cborg-tests/build/cborg-tests/cborg-)
    at h$runThreadSliceCatch (/home/coot/src/haskell/cborg/dist-newstyle/build/javascript-ghcjs/ghc-9.12.2/cborg-0.2.10.0/t/cborg-tests/build/cborg-tests/c)
    at Immediate.h$mainLoop [as _onImmediate] (/home/coot/src/haskell/cborg/dist-newstyle/build/javascript-ghcjs/ghc-9.12.2/cborg-0.2.10.0/t/cborg-tests/bu)
    at process.processImmediate (node:internal/timers:483:21)
```

_Setting `stdin` as `/dev/null` avoids an RTS runtime error..._.

Still, just compiling to javascript is a descent progress. 